### PR TITLE
chore: (breaking) cleanup env var and cli flag names

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,10 +6,11 @@ type OpenAIConfig struct {
 	EmbeddingModel string `usage:"OpenAI Embedding model" default:"text-embedding-ada-002" env:"OPENAI_EMBEDDING_MODEL" name:"openai-embedding-model"`
 	APIVersion     string `usage:"OpenAI API version (for Azure)" default:"2024-02-01" env:"OPENAI_API_VERSION" name:"openai-api-version"`
 	APIType        string `usage:"OpenAI API type (OPEN_AI, AZURE, AZURE_AD)" default:"OPEN_AI" env:"OPENAI_API_TYPE" name:"openai-api-type"`
+	AzureOpenAIConfig
 }
 
 type AzureOpenAIConfig struct {
-	Deployment string `usage:"Azure OpenAI deployment name" default:"" env:"OPENAI_AZURE_DEPLOYMENT" name:"openai-azure-deployment"`
+	Deployment string `usage:"Azure OpenAI deployment name (overrides openai-embedding-model, if set)" default:"" env:"OPENAI_AZURE_DEPLOYMENT" name:"openai-azure-deployment"`
 }
 
 type DatabaseConfig struct {


### PR DESCRIPTION
- `OPENAI_BASE_URL` should be the full resource host, e.g. https://myresource.openai.azure.com
- new config option `OPENAI_AZURE_DEPLOYMENT` should be the name of the deployed model (overrides `OPENAI_EMBEDDING_MODEL` if set)