### PR TITLE
Fix ingest bugs, run go imports

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
 	"github.com/gptscript-ai/knowledge/pkg/flows"

--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -5,14 +5,15 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore"
-	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore"
+	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 )
 
 func checkIgnored(path string, ignoreExtensions []string) bool {

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -6,16 +6,17 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/acorn-io/z"
-	"github.com/gptscript-ai/knowledge/pkg/datastore"
-	"github.com/gptscript-ai/knowledge/pkg/index"
-	"github.com/gptscript-ai/knowledge/pkg/server/types"
-	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/acorn-io/z"
+	"github.com/gptscript-ai/knowledge/pkg/datastore"
+	"github.com/gptscript-ai/knowledge/pkg/index"
+	"github.com/gptscript-ai/knowledge/pkg/server/types"
+	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 
 type DefaultClient struct {

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -3,13 +3,14 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/acorn-io/z"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/index"
 	"github.com/gptscript-ai/knowledge/pkg/server/types"
 	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"os"
-	"path/filepath"
 )
 
 type StandaloneClient struct {

--- a/pkg/cmd/askdir.go
+++ b/pkg/cmd/askdir.go
@@ -3,14 +3,15 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
 	"github.com/acorn-io/z"
 	"github.com/gptscript-ai/knowledge/pkg/client"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	flowconfig "github.com/gptscript-ai/knowledge/pkg/flows/config"
 	"github.com/spf13/cobra"
-	"log/slog"
-	"path/filepath"
-	"strings"
 )
 
 type ClientAskDir struct {

--- a/pkg/cmd/create_dataset.go
+++ b/pkg/cmd/create_dataset.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/delete_dataset.go
+++ b/pkg/cmd/delete_dataset.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/get_dataset.go
+++ b/pkg/cmd/get_dataset.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
+	"strings"
+
 	"github.com/acorn-io/z"
 	"github.com/gptscript-ai/knowledge/pkg/client"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
 	flowconfig "github.com/gptscript-ai/knowledge/pkg/flows/config"
 	"github.com/spf13/cobra"
-	"log/slog"
-	"strings"
 )
 
 type ClientIngest struct {

--- a/pkg/cmd/list_datasets.go
+++ b/pkg/cmd/list_datasets.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
+
 	"github.com/acorn-io/cmd"
 	"github.com/gptscript-ai/knowledge/version"
 	"github.com/spf13/cobra"
-	"log/slog"
-	"os"
 )
 
 func init() {

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore"
-	"github.com/spf13/cobra"
 	"os"
 	"strings"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore"
+	"github.com/spf13/cobra"
 )
 
 type ClientResetDatastore struct {

--- a/pkg/cmd/retrieve.go
+++ b/pkg/cmd/retrieve.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	flowconfig "github.com/gptscript-ai/knowledge/pkg/flows/config"
 	"github.com/spf13/cobra"
-	"log/slog"
 )
 
 type ClientRetrieve struct {

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os/signal"
+	"syscall"
+
 	"github.com/gptscript-ai/knowledge/pkg/config"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/server"
 	"github.com/spf13/cobra"
-	"os/signal"
-	"syscall"
 )
 
 // Server is the Server CLI command

--- a/pkg/datastore/dataset.go
+++ b/pkg/datastore/dataset.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
 	"github.com/gptscript-ai/knowledge/pkg/index"
 	"gorm.io/gorm"
-	"log/slog"
 )
 
 func (s *Datastore) NewDataset(ctx context.Context, dataset index.Dataset) error {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -3,6 +3,9 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net/url"
+
 	"github.com/acorn-io/z"
 	"github.com/adrg/xdg"
 	"github.com/gptscript-ai/knowledge/pkg/config"
@@ -11,8 +14,6 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"github.com/gptscript-ai/knowledge/pkg/vectorstore/chromem"
 	cg "github.com/philippgille/chromem-go"
-	"log/slog"
-	"net/url"
 )
 
 type Datastore struct {

--- a/pkg/datastore/deduplication.go
+++ b/pkg/datastore/deduplication.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+
 	"github.com/gptscript-ai/knowledge/pkg/index"
 )
 

--- a/pkg/datastore/document.go
+++ b/pkg/datastore/document.go
@@ -3,8 +3,9 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/index"
 	"log/slog"
+
+	"github.com/gptscript-ai/knowledge/pkg/index"
 )
 
 func (s *Datastore) DeleteDocument(ctx context.Context, documentID, datasetID string) error {

--- a/pkg/datastore/documentloader/adapter.go
+++ b/pkg/datastore/documentloader/adapter.go
@@ -2,6 +2,7 @@ package documentloader
 
 import (
 	"context"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"

--- a/pkg/datastore/documentloader/defaults.go
+++ b/pkg/datastore/documentloader/defaults.go
@@ -6,14 +6,15 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	golcdocloaders "github.com/hupe1980/golc/documentloader"
 	"github.com/ledongthuc/pdf"
 	"github.com/lu4p/cat"
 	lcgodocloaders "github.com/tmc/langchaingo/documentloaders"
-	"io"
-	"log/slog"
-	"strings"
 )
 
 func DefaultDocLoaderFunc(filetype string) func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {

--- a/pkg/datastore/documentloader/documentloaders.go
+++ b/pkg/datastore/documentloader/documentloaders.go
@@ -6,14 +6,15 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	golcdocloaders "github.com/hupe1980/golc/documentloader"
 	"github.com/lu4p/cat"
 	"github.com/mitchellh/mapstructure"
 	lcgodocloaders "github.com/tmc/langchaingo/documentloaders"
-	"io"
-	"log/slog"
-	"strings"
 )
 
 func GetDocumentLoaderConfig(name string) (any, error) {

--- a/pkg/datastore/documentloader/pdf.go
+++ b/pkg/datastore/documentloader/pdf.go
@@ -1,22 +1,20 @@
 package documentloader
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"github.com/ledongthuc/pdf"
 )
 
 /*
  * Credits to https://github.com/hupe1980/golc/blob/main/documentloader/pdf.go
  */
-
-import (
-	"context"
-	"fmt"
-	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"github.com/ledongthuc/pdf"
-	"io"
-	"os"
-	"strings"
-)
 
 // Compile time check to ensure PDF satisfies the DocumentLoader interface.
 var _ types.DocumentLoader = (*PDF)(nil)

--- a/pkg/datastore/files.go
+++ b/pkg/datastore/files.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/gptscript-ai/knowledge/pkg/index"
 )
 

--- a/pkg/datastore/filetypes/filetypes.go
+++ b/pkg/datastore/filetypes/filetypes.go
@@ -2,10 +2,11 @@ package filetypes
 
 import (
 	"fmt"
-	"github.com/gabriel-vasile/mimetype"
 	"log/slog"
 	"path"
 	"strings"
+
+	"github.com/gabriel-vasile/mimetype"
 )
 
 var FirstclassFileExtensions = map[string]struct{}{

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+
 	"github.com/acorn-io/z"
 	"github.com/google/uuid"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/filetypes"
@@ -11,7 +13,6 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/datastore/transformers"
 	"github.com/gptscript-ai/knowledge/pkg/flows"
 	"github.com/gptscript-ai/knowledge/pkg/index"
-	"log/slog"
 )
 
 type IngestOpts struct {

--- a/pkg/datastore/ingest_test.go
+++ b/pkg/datastore/ingest_test.go
@@ -2,14 +2,15 @@ package datastore
 
 import (
 	"context"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/transformers"
-	"github.com/gptscript-ai/knowledge/pkg/flows"
-	"github.com/stretchr/testify/require"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/transformers"
+	"github.com/gptscript-ai/knowledge/pkg/flows"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractPDF(t *testing.T) {

--- a/pkg/datastore/postprocessors/postprocessors.go
+++ b/pkg/datastore/postprocessors/postprocessors.go
@@ -3,6 +3,7 @@ package postprocessors
 
 import (
 	"fmt"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/transformers"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
 )

--- a/pkg/datastore/querymodifiers/spellcheck.go
+++ b/pkg/datastore/querymodifiers/spellcheck.go
@@ -3,6 +3,7 @@ package querymodifiers
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/gptscript-ai/knowledge/pkg/llm"
 )
 

--- a/pkg/datastore/retrieve.go
+++ b/pkg/datastore/retrieve.go
@@ -2,10 +2,11 @@ package datastore
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
 	"github.com/gptscript-ai/knowledge/pkg/flows"
 	"github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"log/slog"
 )
 
 type RetrieveOpts struct {
@@ -14,16 +15,17 @@ type RetrieveOpts struct {
 }
 
 func (s *Datastore) Retrieve(ctx context.Context, datasetID string, query string, opts RetrieveOpts) ([]vectorstore.Document, error) {
-	if opts.TopK <= 0 {
-		opts.TopK = defaults.TopK
-	}
 	slog.Debug("Retrieving content from dataset", "dataset", datasetID, "query", query)
 
 	retrievalFlow := opts.RetrievalFlow
 	if retrievalFlow == nil {
 		retrievalFlow = &flows.RetrievalFlow{}
 	}
-	retrievalFlow.FillDefaults()
+	topK := defaults.TopK
+	if opts.TopK > 0 {
+		topK = opts.TopK
+	}
+	retrievalFlow.FillDefaults(topK)
 
 	slog.Debug("Retrieval flow", "flow", *retrievalFlow)
 

--- a/pkg/datastore/retrievers/retrievers.go
+++ b/pkg/datastore/retrievers/retrievers.go
@@ -2,9 +2,10 @@ package retrievers
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"log/slog"
 )
 
 type Retriever interface {

--- a/pkg/datastore/textsplitter/textsplitter.go
+++ b/pkg/datastore/textsplitter/textsplitter.go
@@ -1,13 +1,14 @@
 package textsplitter
 
 import (
-	"dario.cat/mergo"
 	"fmt"
+	"log/slog"
+
+	"dario.cat/mergo"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"github.com/mitchellh/mapstructure"
 	lcgosplitter "github.com/tmc/langchaingo/textsplitter"
-	"log/slog"
 )
 
 type SplitterFunc func([]vs.Document) ([]vs.Document, error)
@@ -46,6 +47,7 @@ func NewLcgoMarkdownSplitter(opts TextSplitterOpts) *lcgosplitter.MarkdownTextSp
 		lcgosplitter.WithModelName(opts.ModelName),
 		lcgosplitter.WithEncodingName(opts.EncodingName),
 		lcgosplitter.WithHeadingHierarchy(true),
+		lcgosplitter.WithCodeBlocks(true),
 	)
 }
 

--- a/pkg/datastore/textsplitter/textsplitter_test.go
+++ b/pkg/datastore/textsplitter/textsplitter_test.go
@@ -1,8 +1,9 @@
 package textsplitter
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTextSplitterConfigWithValidName(t *testing.T) {

--- a/pkg/datastore/transformers/generic.go
+++ b/pkg/datastore/transformers/generic.go
@@ -2,6 +2,7 @@ package transformers
 
 import (
 	"context"
+
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 

--- a/pkg/datastore/transformers/keywords.go
+++ b/pkg/datastore/transformers/keywords.go
@@ -2,10 +2,11 @@ package transformers
 
 import (
 	"context"
-	"github.com/gptscript-ai/knowledge/pkg/llm"
-	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"log/slog"
 	"strings"
+
+	"github.com/gptscript-ai/knowledge/pkg/llm"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 
 func NewKeyWordExtractor(numKeywords int, llm llm.LLM) *KeywordExtractor {

--- a/pkg/datastore/transformers/markdown.go
+++ b/pkg/datastore/transformers/markdown.go
@@ -2,8 +2,9 @@ package transformers
 
 import (
 	"context"
-	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"strings"
+
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 
 // FilterMarkdownDocsNoContent filters out Markdown documents with no content or only headings
@@ -18,6 +19,7 @@ func (f *FilterMarkdownDocsNoContent) Transform(_ context.Context, docs []vs.Doc
 			for _, line := range strings.Split(doc.Content, "\n") {
 				if !strings.HasPrefix(line, "#") {
 					filteredDocs = append(filteredDocs, doc)
+					break
 				}
 			}
 		}

--- a/pkg/datastore/transformers/metadata.go
+++ b/pkg/datastore/transformers/metadata.go
@@ -2,6 +2,7 @@ package transformers
 
 import (
 	"context"
+
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 

--- a/pkg/datastore/transformers/transformers.go
+++ b/pkg/datastore/transformers/transformers.go
@@ -2,6 +2,7 @@ package transformers
 
 import (
 	"fmt"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
 )
 

--- a/pkg/datastore/types/types.go
+++ b/pkg/datastore/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 

--- a/pkg/flows/config/config.go
+++ b/pkg/flows/config/config.go
@@ -3,6 +3,10 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/postprocessors"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/querymodifiers"
@@ -11,10 +15,7 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/datastore/transformers"
 	"github.com/gptscript-ai/knowledge/pkg/flows"
 	"github.com/mitchellh/mapstructure"
-	"log/slog"
-	"os"
 	"sigs.k8s.io/yaml"
-	"strings"
 )
 
 type GenericBaseConfig struct {

--- a/pkg/flows/config/config_test.go
+++ b/pkg/flows/config/config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestLoadConfigFromValidJSONFile(t *testing.T) {

--- a/pkg/flows/flows.go
+++ b/pkg/flows/flows.go
@@ -3,7 +3,10 @@ package flows
 import (
 	"context"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
+	"io"
+	"log/slog"
+	"slices"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/postprocessors"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/querymodifiers"
@@ -12,9 +15,6 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/datastore/transformers"
 	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"io"
-	"log/slog"
-	"slices"
 )
 
 type IngestionFlow struct {
@@ -102,10 +102,10 @@ type RetrievalFlow struct {
 	Postprocessors []postprocessors.Postprocessor
 }
 
-func (f *RetrievalFlow) FillDefaults() {
+func (f *RetrievalFlow) FillDefaults(topK int) {
 	if f.Retriever == nil {
 		slog.Debug("No retriever specified, using basic retriever")
-		f.Retriever = &retrievers.BasicRetriever{TopK: defaults.TopK}
+		f.Retriever = &retrievers.BasicRetriever{TopK: topK}
 	}
 }
 

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+
 	"github.com/gptscript-ai/knowledge/pkg/config"
 	golcmodel "github.com/hupe1980/golc/model"
 	"github.com/hupe1980/golc/model/chatmodel"

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -4,13 +4,14 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net/http"
+
 	"github.com/acorn-io/z"
 	"github.com/gin-gonic/gin"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/index"
 	"github.com/gptscript-ai/knowledge/pkg/server/types"
-	"log/slog"
-	"net/http"
 )
 
 // CreateDS creates a new dataset.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,14 +2,15 @@ package server
 
 import (
 	"context"
+	"log/slog"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gptscript-ai/knowledge/pkg/config"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/docs"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
-	"log/slog"
-	"net/http"
 )
 
 type Config struct {

--- a/pkg/vectorstore/chromem/chromem.go
+++ b/pkg/vectorstore/chromem/chromem.go
@@ -2,13 +2,14 @@ package chromem
 
 import (
 	"context"
-	"github.com/google/uuid"
-	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
-	"github.com/philippgille/chromem-go"
 	"log/slog"
 	"maps"
 	"runtime"
 	"strconv"
+
+	"github.com/google/uuid"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"github.com/philippgille/chromem-go"
 )
 
 type Store struct {


### PR DESCRIPTION
When ingesting markdown files, due to a bug in transform some chunks are added multiple times with duplicates. This will cause retrieve process to return duplicate results, impacting its ability to return the relevant information. This PR fixes the transformer bug. 

It also runs goimports on all the files to format imports.