### PR TITLE
change: no error on empty collection, so that the LLM session can 'recover' from the tool call

### DIFF
--- a/pkg/cmd/retrieve.go
+++ b/pkg/cmd/retrieve.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	vserr "github.com/gptscript-ai/knowledge/pkg/vectorstore/errors"
 	"log/slog"
 
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
@@ -73,6 +75,11 @@ func (s *ClientRetrieve) Run(cmd *cobra.Command, args []string) error {
 
 	sources, err := c.Retrieve(cmd.Context(), datasetID, query, retrieveOpts)
 	if err != nil {
+		// An empty collection is not a hard error - the LLM session can "recover" from it
+		if errors.Is(err, vserr.ErrCollectionEmpty) {
+			fmt.Printf("Dataset %q does not contain any documents\n", datasetID)
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/vectorstore/errors.go
+++ b/pkg/vectorstore/errors.go
@@ -1,9 +1,0 @@
-package vectorstore
-
-type ErrCollectionNotFound struct {
-	Collection string
-}
-
-func (e ErrCollectionNotFound) Error() string {
-	return "collection not found: " + e.Collection
-}

--- a/pkg/vectorstore/errors/errors.go
+++ b/pkg/vectorstore/errors/errors.go
@@ -1,0 +1,10 @@
+package errors
+
+import (
+	"errors"
+)
+
+var (
+	ErrCollectionNotFound = errors.New("collection not found")
+	ErrCollectionEmpty    = errors.New("collection is empty")
+)


### PR DESCRIPTION
The error `nResults must be > 0` often happens because we reduce the number of requested documents to be <= the number of available documents in a dataset. If the dataset is empty, this is not actually a hard error but something that we can let the LLM session (GPTScript) know without erroring out.