### PR TITLE
add: basic markdown splitter with limited options

### DIFF
--- a/pkg/datastore/textsplitter/markdown_basic/markdown_basic.go
+++ b/pkg/datastore/textsplitter/markdown_basic/markdown_basic.go
@@ -1,0 +1,293 @@
+package markdown_basic
+
+import (
+	"fmt"
+	lcgosplitter "github.com/tmc/langchaingo/textsplitter"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+
+	"gitlab.com/golang-commonmark/markdown"
+)
+
+// NewMarkdownTextSplitter creates a new Markdown text splitter.
+func NewMarkdownTextSplitter(opts ...Option) *MarkdownTextSplitter {
+	options := DefaultOptions()
+
+	sp := &MarkdownTextSplitter{
+		ChunkSize:      options.ChunkSize,
+		ChunkOverlap:   options.ChunkOverlap,
+		SecondSplitter: options.SecondSplitter,
+	}
+
+	if sp.SecondSplitter == nil {
+		sp.SecondSplitter = lcgosplitter.NewRecursiveCharacter(
+			lcgosplitter.WithChunkSize(options.ChunkSize),
+			lcgosplitter.WithChunkOverlap(options.ChunkOverlap),
+			lcgosplitter.WithSeparators([]string{
+				"\n\n", // new line
+				"\n",   // new line
+				" ",    // space
+			}),
+		)
+	}
+
+	return sp
+}
+
+// MarkdownTextSplitter markdown header text splitter.
+//
+// If your origin document is HTML, you purify and convert to markdown,
+// then split it.
+type MarkdownTextSplitter struct {
+	ChunkSize    int
+	ChunkOverlap int
+	// SecondSplitter splits paragraphs
+	SecondSplitter   lcgosplitter.TextSplitter
+	CodeBlocks       bool
+	ReferenceLinks   bool
+	HeadingHierarchy bool
+
+	MaxHeadingLevel int
+
+	SplitOnListItems    bool
+	SplitOnHeadingsOnly bool
+}
+
+// SplitText splits a text into multiple text.
+func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
+	mdParser := markdown.New(markdown.XHTMLOutput(true))
+	tokens := mdParser.Parse([]byte(text))
+
+	mc := &markdownContext{
+		startAt:        0,
+		endAt:          len(tokens),
+		tokens:         tokens,
+		chunkSize:      sp.ChunkSize,
+		chunkOverlap:   sp.ChunkOverlap,
+		secondSplitter: sp.SecondSplitter,
+		hTitleStack:    []string{},
+	}
+
+	chunks := mc.splitText()
+
+	return chunks, nil
+}
+
+// markdownContext the helper.
+type markdownContext struct {
+	// startAt represents the start position of the cursor in tokens
+	startAt int
+	// endAt represents the end position of the cursor in tokens
+	endAt int
+	// tokens represents the markdown tokens
+	tokens []markdown.Token
+
+	// hTitle represents the current header(H1、H2 etc.) content
+	hTitle string
+	// hTitleStack represents the hierarchy of headers
+	hTitleStack []string
+	// hTitlePrepended represents whether hTitle has been appended to chunks
+	hTitlePrepended bool
+
+	// chunks represents the final chunks
+	chunks []string
+	// curSnippet represents the current short markdown-format chunk
+	curSnippet string
+	// chunkSize represents the max chunk size, when exceeds, it will be split again
+	chunkSize int
+	// chunkOverlap represents the overlap size for each chunk
+	chunkOverlap int
+
+	// secondSplitter re-split markdown single long paragraph into chunks
+	secondSplitter lcgosplitter.TextSplitter
+}
+
+// splitText splits Markdown text.
+//
+//nolint:cyclop
+func (mc *markdownContext) splitText() []string {
+	for idx := mc.startAt; idx < mc.endAt; {
+		token := mc.tokens[idx]
+		switch token.(type) {
+		case *markdown.HeadingOpen:
+			mc.onMDHeader()
+		default:
+			mc.startAt = indexOfCloseTag(mc.tokens, idx) + 1
+		}
+
+		idx = mc.startAt
+	}
+
+	// apply the last chunk
+	mc.applyToChunks()
+
+	return mc.chunks
+}
+
+// clone clones the markdownContext with sub tokens.
+func (mc *markdownContext) clone(startAt, endAt int) *markdownContext {
+	subTokens := mc.tokens[startAt : endAt+1]
+	return &markdownContext{
+		endAt:  len(subTokens),
+		tokens: subTokens,
+
+		hTitle:          mc.hTitle,
+		hTitleStack:     mc.hTitleStack,
+		hTitlePrepended: mc.hTitlePrepended,
+
+		chunkSize:      mc.chunkSize,
+		chunkOverlap:   mc.chunkOverlap,
+		secondSplitter: mc.secondSplitter,
+	}
+}
+
+// onMDHeader splits H1/H2/.../H6
+//
+// format: HeadingOpen/Inline/HeadingClose
+func (mc *markdownContext) onMDHeader() {
+	endAt := indexOfCloseTag(mc.tokens, mc.startAt)
+	defer func() {
+		mc.startAt = endAt + 1
+	}()
+
+	header, ok := mc.tokens[mc.startAt].(*markdown.HeadingOpen)
+	if !ok {
+		return
+	}
+
+	// check next token is Inline
+	inline, ok := mc.tokens[mc.startAt+1].(*markdown.Inline)
+	if !ok {
+		return
+	}
+
+	title := fmt.Sprintf("%s %s", repeatString(header.HLevel, "#"), inline.Content)
+
+	mc.applyToChunks() // change header, apply to chunks
+
+	mc.hTitle = title
+
+	// fill titlestack with empty strings up to the current level
+	for len(mc.hTitleStack) < header.HLevel {
+		mc.hTitleStack = append(mc.hTitleStack, "")
+	}
+
+	// Build the new title from the title stack, joined by newlines, while ignoring empty entries
+	mc.hTitleStack = append(mc.hTitleStack[:header.HLevel-1], mc.hTitle)
+	mc.hTitle = ""
+	for _, t := range mc.hTitleStack {
+		if t != "" {
+			mc.hTitle = strings.Join([]string{mc.hTitle, t}, "\n")
+		}
+	}
+	mc.hTitle = strings.TrimLeft(mc.hTitle, "\n")
+
+	mc.hTitlePrepended = false
+}
+
+// joinSnippet join sub snippet to current total snippet.
+func (mc *markdownContext) joinSnippet(snippet string) {
+	if mc.curSnippet == "" {
+		mc.curSnippet = snippet
+		return
+	}
+
+	// check whether current chunk exceeds chunk size, if so, apply to chunks
+	if utf8.RuneCountInString(mc.curSnippet)+utf8.RuneCountInString(snippet) >= mc.chunkSize {
+		mc.applyToChunks()
+		mc.curSnippet = snippet
+	} else {
+		mc.curSnippet = fmt.Sprintf("%s\n%s", mc.curSnippet, snippet)
+	}
+}
+
+// applyToChunks applies current snippet to chunks.
+func (mc *markdownContext) applyToChunks() {
+	defer func() {
+		mc.curSnippet = ""
+	}()
+
+	var chunks []string
+	if mc.curSnippet != "" {
+		// check whether current chunk is over ChunkSize，if so, re-split current chunk
+		if utf8.RuneCountInString(mc.curSnippet) <= mc.chunkSize+mc.chunkOverlap {
+			chunks = []string{mc.curSnippet}
+		} else {
+			// split current snippet to chunks
+			chunks, _ = mc.secondSplitter.SplitText(mc.curSnippet)
+		}
+	}
+
+	// if there is only H1/H2 and so on, just apply the `Header Title` to chunks
+	if len(chunks) == 0 && mc.hTitle != "" && !mc.hTitlePrepended {
+		mc.chunks = append(mc.chunks, mc.hTitle)
+		mc.hTitlePrepended = true
+		return
+	}
+
+	for _, chunk := range chunks {
+		if chunk == "" {
+			continue
+		}
+
+		mc.hTitlePrepended = true
+		if mc.hTitle != "" && !strings.Contains(mc.curSnippet, mc.hTitle) {
+			// prepend `Header Title` to chunk
+			chunk = fmt.Sprintf("%s\n%s", mc.hTitle, chunk)
+		}
+		mc.chunks = append(mc.chunks, chunk)
+	}
+}
+
+// closeTypes represents the close operation type for each open operation type.
+var closeTypes = map[reflect.Type]reflect.Type{ //nolint:gochecknoglobals
+	reflect.TypeOf(&markdown.HeadingOpen{}):     reflect.TypeOf(&markdown.HeadingClose{}),
+	reflect.TypeOf(&markdown.BulletListOpen{}):  reflect.TypeOf(&markdown.BulletListClose{}),
+	reflect.TypeOf(&markdown.OrderedListOpen{}): reflect.TypeOf(&markdown.OrderedListClose{}),
+	reflect.TypeOf(&markdown.ParagraphOpen{}):   reflect.TypeOf(&markdown.ParagraphClose{}),
+	reflect.TypeOf(&markdown.BlockquoteOpen{}):  reflect.TypeOf(&markdown.BlockquoteClose{}),
+	reflect.TypeOf(&markdown.ListItemOpen{}):    reflect.TypeOf(&markdown.ListItemClose{}),
+	reflect.TypeOf(&markdown.TableOpen{}):       reflect.TypeOf(&markdown.TableClose{}),
+	reflect.TypeOf(&markdown.TheadOpen{}):       reflect.TypeOf(&markdown.TheadClose{}),
+	reflect.TypeOf(&markdown.TbodyOpen{}):       reflect.TypeOf(&markdown.TbodyClose{}),
+}
+
+// indexOfCloseTag returns the index of the close tag for the open tag at startAt.
+func indexOfCloseTag(tokens []markdown.Token, startAt int) int {
+	sameCount := 0
+	openType := reflect.ValueOf(tokens[startAt]).Type()
+	closeType := closeTypes[openType]
+
+	// some tokens (like Hr or Fence) are singular, i.e. they don't have a close type.
+	if closeType == nil {
+		return startAt
+	}
+
+	idx := startAt + 1
+	for ; idx < len(tokens); idx++ {
+		cur := reflect.ValueOf(tokens[idx]).Type()
+
+		if openType == cur {
+			sameCount++
+		}
+
+		if closeType == cur {
+			if sameCount == 0 {
+				break
+			}
+			sameCount--
+		}
+	}
+
+	return idx
+}
+
+// repeatString repeats the initChar for count times.
+func repeatString(count int, initChar string) string {
+	var s string
+	for i := 0; i < count; i++ {
+		s += initChar
+	}
+	return s
+}

--- a/pkg/datastore/textsplitter/markdown_basic/markdown_basic.go
+++ b/pkg/datastore/textsplitter/markdown_basic/markdown_basic.go
@@ -1,293 +1,166 @@
 package markdown_basic
 
 import (
-	"fmt"
 	lcgosplitter "github.com/tmc/langchaingo/textsplitter"
-	"reflect"
 	"strings"
 	"unicode/utf8"
-
-	"gitlab.com/golang-commonmark/markdown"
 )
 
 // NewMarkdownTextSplitter creates a new Markdown text splitter.
 func NewMarkdownTextSplitter(opts ...Option) *MarkdownTextSplitter {
 	options := DefaultOptions()
 
-	sp := &MarkdownTextSplitter{
-		ChunkSize:      options.ChunkSize,
-		ChunkOverlap:   options.ChunkOverlap,
-		SecondSplitter: options.SecondSplitter,
+	for _, opt := range opts {
+		opt(&options)
 	}
 
-	if sp.SecondSplitter == nil {
-		sp.SecondSplitter = lcgosplitter.NewRecursiveCharacter(
-			lcgosplitter.WithChunkSize(options.ChunkSize),
-			lcgosplitter.WithChunkOverlap(options.ChunkOverlap),
-			lcgosplitter.WithSeparators([]string{
-				"\n\n", // new line
-				"\n",   // new line
-				" ",    // space
-			}),
-		)
+	sp := &MarkdownTextSplitter{
+		ChunkSize:         options.ChunkSize,
+		ChunkOverlap:      options.ChunkOverlap,
+		SecondSplitter:    options.SecondSplitter,
+		MaxHeadingLevel:   options.MaxHeadingLevel,
+		IgnoreHeadingOnly: options.IgnoreHeadingOnly,
+	}
+
+	if sp.MaxHeadingLevel == 0 {
+		sp.MaxHeadingLevel = 6
 	}
 
 	return sp
 }
 
 // MarkdownTextSplitter markdown header text splitter.
-//
-// If your origin document is HTML, you purify and convert to markdown,
-// then split it.
 type MarkdownTextSplitter struct {
 	ChunkSize    int
 	ChunkOverlap int
 	// SecondSplitter splits paragraphs
-	SecondSplitter   lcgosplitter.TextSplitter
-	CodeBlocks       bool
-	ReferenceLinks   bool
-	HeadingHierarchy bool
+	SecondSplitter lcgosplitter.TextSplitter
 
 	MaxHeadingLevel int
 
-	SplitOnListItems    bool
-	SplitOnHeadingsOnly bool
+	IgnoreHeadingOnly bool
 }
 
 // SplitText splits a text into multiple text.
 func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
-	mdParser := markdown.New(markdown.XHTMLOutput(true))
-	tokens := mdParser.Parse([]byte(text))
 
-	mc := &markdownContext{
-		startAt:        0,
-		endAt:          len(tokens),
-		tokens:         tokens,
-		chunkSize:      sp.ChunkSize,
-		chunkOverlap:   sp.ChunkOverlap,
-		secondSplitter: sp.SecondSplitter,
-		hTitleStack:    []string{},
+	// Parse markdown line-by-line
+	headerStack := make([]string, sp.MaxHeadingLevel)
+	chunks := []string{}
+	currentHeaderLevel := 1
+	var currentChunk []string
+	var err error
+
+	for _, line := range strings.Split(text, "\n") {
+
+		// Handle headers: maintian a header stack
+		if strings.HasPrefix(line, "#") {
+			// Get the header level
+			headerLevel := strings.Count(strings.Split(line, " ")[0], "#") - 1
+
+			// If the header level is less than or equal to the max heading level
+			if headerLevel < sp.MaxHeadingLevel {
+				headerStack = append(headerStack[:headerLevel], line)
+
+				// Clear the header stack for lower level headers
+				for j := headerLevel + 1; j < len(headerStack); j++ {
+					headerStack[j] = ""
+				}
+
+				// Reset header stack indices between this level and the last seen level, backwards
+				for j := headerLevel - 1; j > currentHeaderLevel; j-- {
+					headerStack[j] = ""
+				}
+
+				// If the current chunk is not empty, add it to the chunks
+				chunks, currentChunk, err = sp.flushChunk(chunks, currentChunk)
+				if err != nil {
+					return nil, err
+				}
+				for _, header := range headerStack {
+					if header != "" {
+						currentChunk = append(currentChunk, header)
+					}
+				}
+
+				currentHeaderLevel = headerLevel
+				continue
+			}
+		}
+
+		// If the line is not a header, add it to the current chunk
+		currentChunk = append(currentChunk, line)
 	}
 
-	chunks := mc.splitText()
+	chunks, currentChunk, err = sp.flushChunk(chunks, currentChunk)
+	if err != nil {
+		return nil, err
+	}
 
 	return chunks, nil
 }
 
-// markdownContext the helper.
-type markdownContext struct {
-	// startAt represents the start position of the cursor in tokens
-	startAt int
-	// endAt represents the end position of the cursor in tokens
-	endAt int
-	// tokens represents the markdown tokens
-	tokens []markdown.Token
+func (sp MarkdownTextSplitter) flushChunk(chunks []string, currentChunk []string) ([]string, []string, error) {
 
-	// hTitle represents the current header(H1、H2 etc.) content
-	hTitle string
-	// hTitleStack represents the hierarchy of headers
-	hTitleStack []string
-	// hTitlePrepended represents whether hTitle has been appended to chunks
-	hTitlePrepended bool
+	// Ignore heading only chunks if the option is set and the last line in the chunk is a header
+	if sp.IgnoreHeadingOnly && strings.HasPrefix(currentChunk[len(currentChunk)-1], "#") {
+		return chunks, []string{}, nil
+	}
 
-	// chunks represents the final chunks
-	chunks []string
-	// curSnippet represents the current short markdown-format chunk
-	curSnippet string
-	// chunkSize represents the max chunk size, when exceeds, it will be split again
-	chunkSize int
-	// chunkOverlap represents the overlap size for each chunk
-	chunkOverlap int
-
-	// secondSplitter re-split markdown single long paragraph into chunks
-	secondSplitter lcgosplitter.TextSplitter
-}
-
-// splitText splits Markdown text.
-//
-//nolint:cyclop
-func (mc *markdownContext) splitText() []string {
-	for idx := mc.startAt; idx < mc.endAt; {
-		token := mc.tokens[idx]
-		switch token.(type) {
-		case *markdown.HeadingOpen:
-			mc.onMDHeader()
-		default:
-			mc.startAt = indexOfCloseTag(mc.tokens, idx) + 1
+	headings := []string{}
+	for i, line := range currentChunk {
+		if i >= sp.MaxHeadingLevel {
+			break
 		}
 
-		idx = mc.startAt
-	}
-
-	// apply the last chunk
-	mc.applyToChunks()
-
-	return mc.chunks
-}
-
-// clone clones the markdownContext with sub tokens.
-func (mc *markdownContext) clone(startAt, endAt int) *markdownContext {
-	subTokens := mc.tokens[startAt : endAt+1]
-	return &markdownContext{
-		endAt:  len(subTokens),
-		tokens: subTokens,
-
-		hTitle:          mc.hTitle,
-		hTitleStack:     mc.hTitleStack,
-		hTitlePrepended: mc.hTitlePrepended,
-
-		chunkSize:      mc.chunkSize,
-		chunkOverlap:   mc.chunkOverlap,
-		secondSplitter: mc.secondSplitter,
-	}
-}
-
-// onMDHeader splits H1/H2/.../H6
-//
-// format: HeadingOpen/Inline/HeadingClose
-func (mc *markdownContext) onMDHeader() {
-	endAt := indexOfCloseTag(mc.tokens, mc.startAt)
-	defer func() {
-		mc.startAt = endAt + 1
-	}()
-
-	header, ok := mc.tokens[mc.startAt].(*markdown.HeadingOpen)
-	if !ok {
-		return
-	}
-
-	// check next token is Inline
-	inline, ok := mc.tokens[mc.startAt+1].(*markdown.Inline)
-	if !ok {
-		return
-	}
-
-	title := fmt.Sprintf("%s %s", repeatString(header.HLevel, "#"), inline.Content)
-
-	mc.applyToChunks() // change header, apply to chunks
-
-	mc.hTitle = title
-
-	// fill titlestack with empty strings up to the current level
-	for len(mc.hTitleStack) < header.HLevel {
-		mc.hTitleStack = append(mc.hTitleStack, "")
-	}
-
-	// Build the new title from the title stack, joined by newlines, while ignoring empty entries
-	mc.hTitleStack = append(mc.hTitleStack[:header.HLevel-1], mc.hTitle)
-	mc.hTitle = ""
-	for _, t := range mc.hTitleStack {
-		if t != "" {
-			mc.hTitle = strings.Join([]string{mc.hTitle, t}, "\n")
-		}
-	}
-	mc.hTitle = strings.TrimLeft(mc.hTitle, "\n")
-
-	mc.hTitlePrepended = false
-}
-
-// joinSnippet join sub snippet to current total snippet.
-func (mc *markdownContext) joinSnippet(snippet string) {
-	if mc.curSnippet == "" {
-		mc.curSnippet = snippet
-		return
-	}
-
-	// check whether current chunk exceeds chunk size, if so, apply to chunks
-	if utf8.RuneCountInString(mc.curSnippet)+utf8.RuneCountInString(snippet) >= mc.chunkSize {
-		mc.applyToChunks()
-		mc.curSnippet = snippet
-	} else {
-		mc.curSnippet = fmt.Sprintf("%s\n%s", mc.curSnippet, snippet)
-	}
-}
-
-// applyToChunks applies current snippet to chunks.
-func (mc *markdownContext) applyToChunks() {
-	defer func() {
-		mc.curSnippet = ""
-	}()
-
-	var chunks []string
-	if mc.curSnippet != "" {
-		// check whether current chunk is over ChunkSize，if so, re-split current chunk
-		if utf8.RuneCountInString(mc.curSnippet) <= mc.chunkSize+mc.chunkOverlap {
-			chunks = []string{mc.curSnippet}
-		} else {
-			// split current snippet to chunks
-			chunks, _ = mc.secondSplitter.SplitText(mc.curSnippet)
-		}
-	}
-
-	// if there is only H1/H2 and so on, just apply the `Header Title` to chunks
-	if len(chunks) == 0 && mc.hTitle != "" && !mc.hTitlePrepended {
-		mc.chunks = append(mc.chunks, mc.hTitle)
-		mc.hTitlePrepended = true
-		return
-	}
-
-	for _, chunk := range chunks {
-		if chunk == "" {
+		if strings.HasPrefix(line, "#") {
+			headings = append(headings, line)
 			continue
 		}
-
-		mc.hTitlePrepended = true
-		if mc.hTitle != "" && !strings.Contains(mc.curSnippet, mc.hTitle) {
-			// prepend `Header Title` to chunk
-			chunk = fmt.Sprintf("%s\n%s", mc.hTitle, chunk)
-		}
-		mc.chunks = append(mc.chunks, chunk)
+		break
 	}
-}
+	headerstr := strings.Join(headings, "\n")
+	contentstr := strings.Trim(strings.Join(currentChunk[len(headings):], "\n"), "\n")
+	chunkstr := headerstr + "\n" + contentstr
 
-// closeTypes represents the close operation type for each open operation type.
-var closeTypes = map[reflect.Type]reflect.Type{ //nolint:gochecknoglobals
-	reflect.TypeOf(&markdown.HeadingOpen{}):     reflect.TypeOf(&markdown.HeadingClose{}),
-	reflect.TypeOf(&markdown.BulletListOpen{}):  reflect.TypeOf(&markdown.BulletListClose{}),
-	reflect.TypeOf(&markdown.OrderedListOpen{}): reflect.TypeOf(&markdown.OrderedListClose{}),
-	reflect.TypeOf(&markdown.ParagraphOpen{}):   reflect.TypeOf(&markdown.ParagraphClose{}),
-	reflect.TypeOf(&markdown.BlockquoteOpen{}):  reflect.TypeOf(&markdown.BlockquoteClose{}),
-	reflect.TypeOf(&markdown.ListItemOpen{}):    reflect.TypeOf(&markdown.ListItemClose{}),
-	reflect.TypeOf(&markdown.TableOpen{}):       reflect.TypeOf(&markdown.TableClose{}),
-	reflect.TypeOf(&markdown.TheadOpen{}):       reflect.TypeOf(&markdown.TheadClose{}),
-	reflect.TypeOf(&markdown.TbodyOpen{}):       reflect.TypeOf(&markdown.TbodyClose{}),
-}
+	if chunkstr != "" && chunkstr != "\n" {
+		if sp.SecondSplitter != nil {
 
-// indexOfCloseTag returns the index of the close tag for the open tag at startAt.
-func indexOfCloseTag(tokens []markdown.Token, startAt int) int {
-	sameCount := 0
-	openType := reflect.ValueOf(tokens[startAt]).Type()
-	closeType := closeTypes[openType]
-
-	// some tokens (like Hr or Fence) are singular, i.e. they don't have a close type.
-	if closeType == nil {
-		return startAt
-	}
-
-	idx := startAt + 1
-	for ; idx < len(tokens); idx++ {
-		cur := reflect.ValueOf(tokens[idx]).Type()
-
-		if openType == cur {
-			sameCount++
-		}
-
-		if closeType == cur {
-			if sameCount == 0 {
-				break
+			// Split the chunk into smaller chunks
+			splits, err := sp.SecondSplitter.SplitText(chunkstr)
+			if err != nil {
+				return chunks, []string{}, err
 			}
-			sameCount--
+
+			for _, split := range splits {
+				chunks = append(chunks, split)
+			}
+
+			if len(splits) == 0 {
+				chunks = append(chunks, headerstr)
+			}
+
+		} else {
+			splits, err := lcgosplitter.NewRecursiveCharacter(
+				lcgosplitter.WithChunkSize(sp.ChunkSize-utf8.RuneCountInString(headerstr)),
+				lcgosplitter.WithChunkOverlap(sp.ChunkOverlap),
+				lcgosplitter.WithSeparators([]string{"\n\n", "\n", " ", ""}),
+			).SplitText(contentstr)
+			if err != nil {
+				return chunks, []string{}, err
+			}
+
+			for _, split := range splits {
+				chunks = append(chunks, headerstr+"\n"+split)
+			}
+
+			// headings only
+			if len(splits) == 0 {
+				chunks = append(chunks, headerstr)
+			}
+
 		}
 	}
 
-	return idx
-}
-
-// repeatString repeats the initChar for count times.
-func repeatString(count int, initChar string) string {
-	var s string
-	for i := 0; i < count; i++ {
-		s += initChar
-	}
-	return s
+	return chunks, []string{}, nil
 }

--- a/pkg/datastore/textsplitter/markdown_basic/markdown_basic_test.go
+++ b/pkg/datastore/textsplitter/markdown_basic/markdown_basic_test.go
@@ -1,0 +1,86 @@
+package markdown_basic
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSplitTextWithBasicMarkdown(t *testing.T) {
+	splitter := NewMarkdownTextSplitter()
+	chunks, err := splitter.SplitText("# Heading\n\nThis is a paragraph.")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(chunks))
+
+	expected := []string{"# Heading\nThis is a paragraph."}
+
+	assert.Equal(t, expected, chunks)
+}
+
+func TestSplitTextWithOptions(t *testing.T) {
+
+	md := `
+# Heading 1
+
+some p under h1
+
+## Heading 2
+### Heading 3
+
+- some
+- list
+- items
+
+**bold**
+
+# 2nd Heading 1
+#### Heading 4
+
+some p under h4
+`
+
+	testcases := []struct {
+		name     string
+		splitter *MarkdownTextSplitter
+		expected []string
+	}{
+		{
+			name:     "default",
+			splitter: NewMarkdownTextSplitter(),
+			expected: []string{
+				"# Heading 1\nsome p under h1",
+				"# Heading 1\n## Heading 2",
+				"# Heading 1\n## Heading 2\n### Heading 3\n- some\n- list\n- items\n\n**bold**",
+				"# 2nd Heading 1",
+				"# 2nd Heading 1\n#### Heading 4\nsome p under h4",
+			},
+		},
+		{
+			name:     "ignore_heading_only",
+			splitter: NewMarkdownTextSplitter(WithIgnoreHeadingOnly(true)),
+			expected: []string{
+				"# Heading 1\nsome p under h1",
+				"# Heading 1\n## Heading 2\n### Heading 3\n- some\n- list\n- items\n\n**bold**",
+				"# 2nd Heading 1\n#### Heading 4\nsome p under h4",
+			},
+		},
+		{
+			name:     "split_h1_only",
+			splitter: NewMarkdownTextSplitter(WithMaxHeadingLevel(1)),
+			expected: []string{
+				"# Heading 1\nsome p under h1\n\n## Heading 2\n### Heading 3\n\n- some\n- list\n- items\n\n**bold**",
+				"# 2nd Heading 1\n#### Heading 4\n\nsome p under h4",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunks, err := tc.splitter.SplitText(md)
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.expected), len(chunks))
+
+			assert.Equal(t, tc.expected, chunks)
+		})
+	}
+
+}

--- a/pkg/datastore/textsplitter/markdown_basic/options.go
+++ b/pkg/datastore/textsplitter/markdown_basic/options.go
@@ -1,0 +1,77 @@
+package markdown_basic
+
+import (
+	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
+	lcgosplitter "github.com/tmc/langchaingo/textsplitter"
+)
+
+// Options is a struct that contains options for a text splitter.
+type Options struct {
+	ChunkSize      int
+	ChunkOverlap   int
+	Separators     []string
+	KeepSeparator  bool
+	ModelName      string
+	EncodingName   string
+	SecondSplitter lcgosplitter.TextSplitter
+}
+
+// DefaultOptions returns the default options for all text splitter.
+func DefaultOptions() Options {
+	return Options{
+		ChunkSize:    defaults.TextSplitterChunkSize,
+		ChunkOverlap: defaults.TextSplitterChunkOverlap,
+
+		ModelName:    defaults.TextSplitterTokenModel,
+		EncodingName: defaults.TextSplitterTokenEncoding,
+	}
+}
+
+// Option is a function that can be used to set options for a text splitter.
+type Option func(*Options)
+
+// WithChunkSize sets the chunk size for a text splitter.
+func WithChunkSize(chunkSize int) Option {
+	return func(o *Options) {
+		o.ChunkSize = chunkSize
+	}
+}
+
+// WithChunkOverlap sets the chunk overlap for a text splitter.
+func WithChunkOverlap(chunkOverlap int) Option {
+	return func(o *Options) {
+		o.ChunkOverlap = chunkOverlap
+	}
+}
+
+// WithModelName sets the model name for a text splitter.
+func WithModelName(modelName string) Option {
+	return func(o *Options) {
+		o.ModelName = modelName
+	}
+}
+
+// WithEncodingName sets the encoding name for a text splitter.
+func WithEncodingName(encodingName string) Option {
+	return func(o *Options) {
+		o.EncodingName = encodingName
+	}
+}
+
+// WithSecondSplitter sets the second splitter for a text splitter.
+func WithSecondSplitter(secondSplitter lcgosplitter.TextSplitter) Option {
+	return func(o *Options) {
+		o.SecondSplitter = secondSplitter
+	}
+}
+
+// WithKeepSeparator sets whether the separators should be kept in the resulting
+// split text or not. When it is set to True, the separators are included in the
+// resulting split text. When it is set to False, the separators are not included
+// in the resulting split text. The purpose of having this parameter is to provide
+// flexibility in how text splitting is handled. Default to False if not specified.
+func WithKeepSeparator(keepSeparator bool) Option {
+	return func(o *Options) {
+		o.KeepSeparator = keepSeparator
+	}
+}

--- a/pkg/datastore/textsplitter/markdown_basic/options.go
+++ b/pkg/datastore/textsplitter/markdown_basic/options.go
@@ -14,6 +14,9 @@ type Options struct {
 	ModelName      string
 	EncodingName   string
 	SecondSplitter lcgosplitter.TextSplitter
+
+	MaxHeadingLevel   int  // Maximum heading level to split on
+	IgnoreHeadingOnly bool // Ignore chunks that only contain headings
 }
 
 // DefaultOptions returns the default options for all text splitter.
@@ -24,6 +27,9 @@ func DefaultOptions() Options {
 
 		ModelName:    defaults.TextSplitterTokenModel,
 		EncodingName: defaults.TextSplitterTokenEncoding,
+
+		MaxHeadingLevel:   6,
+		IgnoreHeadingOnly: false,
 	}
 }
 
@@ -73,5 +79,17 @@ func WithSecondSplitter(secondSplitter lcgosplitter.TextSplitter) Option {
 func WithKeepSeparator(keepSeparator bool) Option {
 	return func(o *Options) {
 		o.KeepSeparator = keepSeparator
+	}
+}
+
+func WithMaxHeadingLevel(maxHeadingLevel int) Option {
+	return func(o *Options) {
+		o.MaxHeadingLevel = maxHeadingLevel
+	}
+}
+
+func WithIgnoreHeadingOnly(ignoreHeadingOnly bool) Option {
+	return func(o *Options) {
+		o.IgnoreHeadingOnly = ignoreHeadingOnly
 	}
 }


### PR DESCRIPTION
This PR adds a pretty basic markdown text splitter, that only considers headings for splitting.
One can choose up to which level of headings to split the text and result chunks which are larger than the defined chunkSize will be chunked further by a secondary splitter (default is a recursiveCharacterSplitter).
Every chunk will be prefixed with the whole markdown heading hierarchy, improving the semantic search results.
Optionally, chunks that consist of headings only (i.e. no content) can be ignored/dropped.

The code follows the functional options pattern like the golc and langchaingo libs for consistency.