### PR TITLE
add: commands to export datasets and to import/query them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 toolchain go1.22.4
 
 replace (
-	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20240513080122-88f1efa639f5 // Azure OpenAI support
+	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20240627131850-b7f5672836c8 // Export selected collections
 	github.com/tmc/langchaingo => github.com/StrongMonkey/langchaingo v0.0.0-20240617180437-9af4bee04c8b // Context-Aware Markdown Splitting
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.3
 toolchain go1.22.4
 
 replace (
-	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20240627131850-b7f5672836c8 // Export selected collections
+	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20240701135946-49eb4988eab1 // Import/Export selected collections
 	github.com/tmc/langchaingo => github.com/StrongMonkey/langchaingo v0.0.0-20240617180437-9af4bee04c8b // Context-Aware Markdown Splitting
 )
 

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/hupe1980/golc v0.0.112 h1:aFUMfnEkqdapukuj6/Ny0zbwBDngeC/ZyvvACRdBfv4
 github.com/hupe1980/golc v0.0.112/go.mod h1:w692KzkSTSvXROfyu+jYauNXB4YaL1s8zHPDMnNW88o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/iwilltry42/chromem-go v0.0.0-20240513080122-88f1efa639f5 h1:g3mhp9K4ujkjne0JDvtmP8i36uQlibwzbWKYzZbzcKU=
-github.com/iwilltry42/chromem-go v0.0.0-20240513080122-88f1efa639f5/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
+github.com/iwilltry42/chromem-go v0.0.0-20240627131850-b7f5672836c8 h1:GC4Bk6eE9u2I/uuhyM/LVe1UKAj8gG4MUlrm0d2t7j0=
+github.com/iwilltry42/chromem-go v0.0.0-20240627131850-b7f5672836c8/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7 h1:g0fAGBisHaEQ0TRq1iBvemFRf+8AEWEmBESSiWB3Vsc=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/hupe1980/golc v0.0.112 h1:aFUMfnEkqdapukuj6/Ny0zbwBDngeC/ZyvvACRdBfv4
 github.com/hupe1980/golc v0.0.112/go.mod h1:w692KzkSTSvXROfyu+jYauNXB4YaL1s8zHPDMnNW88o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/iwilltry42/chromem-go v0.0.0-20240627131850-b7f5672836c8 h1:GC4Bk6eE9u2I/uuhyM/LVe1UKAj8gG4MUlrm0d2t7j0=
-github.com/iwilltry42/chromem-go v0.0.0-20240627131850-b7f5672836c8/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
+github.com/iwilltry42/chromem-go v0.0.0-20240701135946-49eb4988eab1 h1:fo4188Or4x3XwtRsAHP+qwzBrvuxDODoRbAWbeM1OaU=
+github.com/iwilltry42/chromem-go v0.0.0-20240701135946-49eb4988eab1/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7 h1:g0fAGBisHaEQ0TRq1iBvemFRf+8AEWEmBESSiWB3Vsc=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,4 +29,5 @@ type Client interface {
 	DeleteDocuments(ctx context.Context, datasetID string, documentIDs ...string) error
 	Retrieve(ctx context.Context, datasetID string, query string, opts datastore.RetrieveOpts) ([]vectorstore.Document, error)
 	ExportDatasets(ctx context.Context, path string, datasets ...string) error
+	ImportDatasets(ctx context.Context, path string, datasets ...string) error
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
 	"github.com/gptscript-ai/knowledge/pkg/flows"
@@ -29,4 +28,5 @@ type Client interface {
 	AskDirectory(ctx context.Context, path string, query string, opts *IngestPathsOpts, ropts *datastore.RetrieveOpts) ([]vectorstore.Document, error)
 	DeleteDocuments(ctx context.Context, datasetID string, documentIDs ...string) error
 	Retrieve(ctx context.Context, datasetID string, query string, opts datastore.RetrieveOpts) ([]vectorstore.Document, error)
+	ExportDatasets(ctx context.Context, path string, datasets ...string) error
 }

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -223,3 +223,8 @@ func (c *DefaultClient) ExportDatasets(ctx context.Context, path string, dataset
 	// TODO: implement
 	panic("not implemented")
 }
+
+func (c *DefaultClient) ImportDatasets(ctx context.Context, path string, datasets ...string) error {
+	// TODO: implement
+	panic("not implemented")
+}

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -218,3 +218,8 @@ func (c *DefaultClient) request(method, path string, body io.Reader) ([]byte, er
 
 	return nil, nil
 }
+
+func (c *DefaultClient) ExportDatasets(ctx context.Context, path string, datasets ...string) error {
+	// TODO: implement
+	panic("not implemented")
+}

--- a/pkg/client/flow.go
+++ b/pkg/client/flow.go
@@ -1,1 +1,0 @@
-package client

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -124,3 +124,7 @@ func (c *StandaloneClient) Retrieve(ctx context.Context, datasetID string, query
 func (c *StandaloneClient) AskDirectory(ctx context.Context, path string, query string, opts *IngestPathsOpts, ropts *datastore.RetrieveOpts) ([]vectorstore.Document, error) {
 	return AskDir(ctx, c, path, query, opts, ropts)
 }
+
+func (c *StandaloneClient) ExportDatasets(ctx context.Context, path string, datasets ...string) error {
+	return c.Datastore.ExportDatasetsToFile(ctx, path, datasets...)
+}

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -128,3 +128,7 @@ func (c *StandaloneClient) AskDirectory(ctx context.Context, path string, query 
 func (c *StandaloneClient) ExportDatasets(ctx context.Context, path string, datasets ...string) error {
 	return c.Datastore.ExportDatasetsToFile(ctx, path, datasets...)
 }
+
+func (c *StandaloneClient) ImportDatasets(ctx context.Context, path string, datasets ...string) error {
+	return c.Datastore.ImportDatasetsFromFile(ctx, path, datasets...)
+}

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"archive/zip"
+	"fmt"
 	"github.com/gptscript-ai/knowledge/pkg/client"
 	"github.com/gptscript-ai/knowledge/pkg/config"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
+	"io"
+	"os"
+	"path/filepath"
 )
 
 type Client struct {
@@ -18,7 +24,70 @@ type ClientFlowsConfig struct {
 	Flow      string `usage:"Flow name" env:"KNOW_FLOW"`
 }
 
+func (s *Client) getClientFromArchive(archive string) (client.Client, error) {
+	// unpack to tempdir
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "knowledge-retrieve-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	r, err := zip.OpenReader(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	if len(r.File) != 2 {
+		return nil, fmt.Errorf("knowledge archive must contain exactly two files, found %d", len(r.File))
+	}
+
+	dbFile := ""
+	vectorStoreFile := ""
+	for _, f := range r.File {
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+
+		path := filepath.Join(tmpDir, f.Name)
+		if f.FileInfo().IsDir() {
+			continue
+		}
+
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		if _, err := io.Copy(f, rc); err != nil {
+			return nil, err
+		}
+		_ = f.Close()
+		_ = rc.Close()
+
+		// FIXME: this should not be static as we may support multiple (vector) DBs at some point
+		if filepath.Ext(f.Name()) == ".db" {
+			dbFile = path
+		} else if filepath.Ext(f.Name()) == ".gob" {
+			vectorStoreFile = path
+		}
+	}
+
+	if dbFile == "" || vectorStoreFile == "" {
+		return nil, fmt.Errorf("knowledge archive must contain exactly one .db and one .gob file")
+	}
+
+	s.DSN = types.ArchivePrefix + dbFile
+	s.VectorDBPath = types.ArchivePrefix + vectorStoreFile
+
+	return s.getClient()
+}
+
 func (s *Client) getClient() (client.Client, error) {
+
 	if s.Server == "" || s.Server == "standalone" {
 		ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, s.OpenAIConfig)
 		if err != nil {

--- a/pkg/cmd/export.go
+++ b/pkg/cmd/export.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+type ClientExportDatasets struct {
+	Client
+	Output string `usage:"Output path" default:"."`
+}
+
+func (s *ClientExportDatasets) Customize(cmd *cobra.Command) {
+	cmd.Use = "export <dataset-id> [<dataset-id>...]"
+	cmd.Short = "Export one or more datasets as an archive (zip)"
+	cmd.Args = cobra.MinimumNArgs(1)
+}
+
+func (s *ClientExportDatasets) Run(cmd *cobra.Command, args []string) error {
+	c, err := s.getClient()
+	if err != nil {
+		return err
+	}
+
+	for _, datasetID := range args {
+		ds, err := c.GetDataset(cmd.Context(), datasetID)
+		if err != nil {
+			return err
+		}
+
+		if ds.ID == "" {
+			return fmt.Errorf("dataset %q not found", datasetID)
+		}
+	}
+
+	return c.ExportDatasets(cmd.Context(), s.Output, args...)
+}

--- a/pkg/cmd/export.go
+++ b/pkg/cmd/export.go
@@ -8,12 +8,12 @@ import (
 type ClientExportDatasets struct {
 	Client
 	Output string `usage:"Output path" default:"."`
+	All    bool   `usage:"Export all datasets" short:"a"`
 }
 
 func (s *ClientExportDatasets) Customize(cmd *cobra.Command) {
 	cmd.Use = "export <dataset-id> [<dataset-id>...]"
 	cmd.Short = "Export one or more datasets as an archive (zip)"
-	cmd.Args = cobra.MinimumNArgs(1)
 }
 
 func (s *ClientExportDatasets) Run(cmd *cobra.Command, args []string) error {
@@ -22,16 +22,35 @@ func (s *ClientExportDatasets) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for _, datasetID := range args {
-		ds, err := c.GetDataset(cmd.Context(), datasetID)
+	if s.All && len(args) > 0 {
+		return fmt.Errorf("cannot use --all with dataset IDs")
+	}
+
+	dsnames := args
+
+	if s.All {
+		lds, err := c.ListDatasets(cmd.Context())
 		if err != nil {
 			return err
 		}
 
-		if ds.ID == "" {
-			return fmt.Errorf("dataset %q not found", datasetID)
+		dsnames = make([]string, len(lds))
+		for i, ds := range lds {
+			dsnames[i] = ds.ID
+		}
+	} else {
+
+		for _, datasetID := range dsnames {
+			ds, err := c.GetDataset(cmd.Context(), datasetID)
+			if err != nil {
+				return err
+			}
+
+			if ds == nil || ds.ID == "" {
+				return fmt.Errorf("dataset %q not found", datasetID)
+			}
 		}
 	}
 
-	return c.ExportDatasets(cmd.Context(), s.Output, args...)
+	return c.ExportDatasets(cmd.Context(), s.Output, dsnames...)
 }

--- a/pkg/cmd/get_dataset.go
+++ b/pkg/cmd/get_dataset.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/client"
-
 	"github.com/spf13/cobra"
 )
 
@@ -21,18 +19,9 @@ func (s *ClientGetDataset) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientGetDataset) Run(cmd *cobra.Command, args []string) error {
-	var err error
-	var c client.Client
-	if s.Archive != "" {
-		c, err = s.getClientFromArchive(s.Archive)
-		if err != nil {
-			return err
-		}
-	} else {
-		c, err = s.getClient()
-		if err != nil {
-			return err
-		}
+	c, err := s.getClient()
+	if err != nil {
+		return err
 	}
 
 	datasetID := args[0]

--- a/pkg/cmd/get_dataset.go
+++ b/pkg/cmd/get_dataset.go
@@ -3,12 +3,15 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gptscript-ai/knowledge/pkg/client"
 
 	"github.com/spf13/cobra"
 )
 
 type ClientGetDataset struct {
 	Client
+	Archive string `usage:"Path to the archive file"`
+	NoDocs  bool   `usage:"Do not include documents in output (way less verbose)"`
 }
 
 func (s *ClientGetDataset) Customize(cmd *cobra.Command) {
@@ -18,9 +21,18 @@ func (s *ClientGetDataset) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientGetDataset) Run(cmd *cobra.Command, args []string) error {
-	c, err := s.getClient()
-	if err != nil {
-		return err
+	var err error
+	var c client.Client
+	if s.Archive != "" {
+		c, err = s.getClientFromArchive(s.Archive)
+		if err != nil {
+			return err
+		}
+	} else {
+		c, err = s.getClient()
+		if err != nil {
+			return err
+		}
 	}
 
 	datasetID := args[0]
@@ -33,6 +45,12 @@ func (s *ClientGetDataset) Run(cmd *cobra.Command, args []string) error {
 	if ds == nil {
 		fmt.Println("dataset not found")
 		return fmt.Errorf("dataset not found")
+	}
+
+	if s.NoDocs {
+		for i := range ds.Files {
+			ds.Files[i].Documents = nil
+		}
 	}
 
 	jsonOutput, err := json.Marshal(ds)

--- a/pkg/cmd/import.go
+++ b/pkg/cmd/import.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type ClientImportDatasets struct {
+	Client
+}
+
+func (s *ClientImportDatasets) Customize(cmd *cobra.Command) {
+	cmd.Use = "import <path> [<dataset-id>...]"
+	cmd.Short = "Import one or more datasets from an archive (zip) (default: all datasets)"
+	cmd.Long = `Import one or more datasets from an archive (zip) (default: all datasets).
+## IMPORTANT: Embedding functions
+   Embedding functions are not part of exported knowledge base archives, so you'll have to know the embedding function used to import the archive.
+   This primarily concerns the choice of the embeddings provider (model) and the embedding dimension.
+   Note: This is only relevant if you plan to add more documents to the dataset after importing it.
+`
+	cmd.Args = cobra.MinimumNArgs(1)
+}
+
+func (s *ClientImportDatasets) Run(cmd *cobra.Command, args []string) error {
+	c, err := s.getClient()
+	if err != nil {
+		return err
+	}
+
+	return c.ImportDatasets(cmd.Context(), args[0], args[1:]...)
+}

--- a/pkg/cmd/list_datasets.go
+++ b/pkg/cmd/list_datasets.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/client"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,18 +18,10 @@ func (s *ClientListDatasets) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientListDatasets) Run(cmd *cobra.Command, args []string) error {
-	var err error
-	var c client.Client
-	if s.Archive != "" {
-		c, err = s.getClientFromArchive(s.Archive)
-		if err != nil {
-			return err
-		}
-	} else {
-		c, err = s.getClient()
-		if err != nil {
-			return err
-		}
+
+	c, err := s.getClient()
+	if err != nil {
+		return err
 	}
 
 	ds, err := c.ListDatasets(cmd.Context())

--- a/pkg/cmd/list_datasets.go
+++ b/pkg/cmd/list_datasets.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gptscript-ai/knowledge/pkg/client"
 
 	"github.com/spf13/cobra"
 )
 
 type ClientListDatasets struct {
 	Client
+	Archive string `usage:"Path to the archive file"`
 }
 
 func (s *ClientListDatasets) Customize(cmd *cobra.Command) {
@@ -18,9 +20,18 @@ func (s *ClientListDatasets) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientListDatasets) Run(cmd *cobra.Command, args []string) error {
-	c, err := s.getClient()
-	if err != nil {
-		return err
+	var err error
+	var c client.Client
+	if s.Archive != "" {
+		c, err = s.getClientFromArchive(s.Archive)
+		if err != nil {
+			return err
+		}
+	} else {
+		c, err = s.getClient()
+		if err != nil {
+			return err
+		}
 	}
 
 	ds, err := c.ListDatasets(cmd.Context())

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -28,6 +28,7 @@ func New() *cobra.Command {
 		new(ClientRetrieve),
 		new(ClientResetDatastore),
 		new(ClientAskDir),
+		new(ClientExportDatasets),
 		new(Version),
 	)
 }

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -29,6 +29,7 @@ func New() *cobra.Command {
 		new(ClientResetDatastore),
 		new(ClientAskDir),
 		new(ClientExportDatasets),
+		new(ClientImportDatasets),
 		new(Version),
 	)
 }

--- a/pkg/cmd/reset.go
+++ b/pkg/cmd/reset.go
@@ -21,7 +21,7 @@ func (s *ClientResetDatastore) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientResetDatastore) Run(cmd *cobra.Command, args []string) error {
-	dsn, vectordbPath, err := datastore.GetDatastorePaths(s.DSN, s.VectorDBConfig.VectorDBPath)
+	dsn, vectordbPath, _, err := datastore.GetDatastorePaths(s.DSN, s.VectorDBConfig.VectorDBPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retrieve.go
+++ b/pkg/cmd/retrieve.go
@@ -4,17 +4,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	vserr "github.com/gptscript-ai/knowledge/pkg/vectorstore/errors"
-	"log/slog"
-
+	"github.com/gptscript-ai/knowledge/pkg/client"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	flowconfig "github.com/gptscript-ai/knowledge/pkg/flows/config"
+	vserr "github.com/gptscript-ai/knowledge/pkg/vectorstore/errors"
 	"github.com/spf13/cobra"
+	"log/slog"
 )
 
 type ClientRetrieve struct {
 	Client
 	Dataset string `usage:"Target Dataset ID" short:"d" default:"default" env:"KNOW_TARGET_DATASET"`
+	Archive string `usage:"Path to the archive file"`
 	ClientRetrieveOpts
 	ClientFlowsConfig
 }
@@ -30,9 +31,19 @@ func (s *ClientRetrieve) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientRetrieve) Run(cmd *cobra.Command, args []string) error {
-	c, err := s.getClient()
-	if err != nil {
-		return err
+
+	var err error
+	var c client.Client
+	if s.Archive != "" {
+		c, err = s.getClientFromArchive(s.Archive)
+		if err != nil {
+			return err
+		}
+	} else {
+		c, err = s.getClient()
+		if err != nil {
+			return err
+		}
 	}
 
 	datasetID := s.Dataset

--- a/pkg/cmd/retrieve.go
+++ b/pkg/cmd/retrieve.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/client"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	flowconfig "github.com/gptscript-ai/knowledge/pkg/flows/config"
 	vserr "github.com/gptscript-ai/knowledge/pkg/vectorstore/errors"
@@ -32,18 +31,9 @@ func (s *ClientRetrieve) Customize(cmd *cobra.Command) {
 
 func (s *ClientRetrieve) Run(cmd *cobra.Command, args []string) error {
 
-	var err error
-	var c client.Client
-	if s.Archive != "" {
-		c, err = s.getClientFromArchive(s.Archive)
-		if err != nil {
-			return err
-		}
-	} else {
-		c, err = s.getClient()
-		if err != nil {
-			return err
-		}
+	c, err := s.getClient()
+	if err != nil {
+		return err
 	}
 
 	datasetID := s.Dataset

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -135,6 +135,12 @@ func (s *Datastore) ExportDatasetsToFile(ctx context.Context, path string, datas
 		return err
 	}
 
+	defer os.RemoveAll(tmpDir)
+
+	if err = s.Index.ExportDatasetsToFile(ctx, tmpDir, datasets...); err != nil {
+		return err
+	}
+
 	if err = s.Vectorstore.ExportCollectionsToFile(ctx, tmpDir, datasets...); err != nil {
 		return err
 	}

--- a/pkg/datastore/textsplitter/markdown_basic/markdown_basic.go
+++ b/pkg/datastore/textsplitter/markdown_basic/markdown_basic.go
@@ -43,7 +43,6 @@ type MarkdownTextSplitter struct {
 
 // SplitText splits a text into multiple text.
 func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
-
 	// Parse markdown line-by-line
 	headerStack := make([]string, sp.MaxHeadingLevel)
 	chunks := []string{}
@@ -52,7 +51,6 @@ func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
 	var err error
 
 	for _, line := range strings.Split(text, "\n") {
-
 		// Handle headers: maintian a header stack
 		if strings.HasPrefix(line, "#") {
 			// Get the header level
@@ -92,7 +90,7 @@ func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
 		currentChunk = append(currentChunk, line)
 	}
 
-	chunks, currentChunk, err = sp.flushChunk(chunks, currentChunk)
+	chunks, _, err = sp.flushChunk(chunks, currentChunk)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +99,6 @@ func (sp MarkdownTextSplitter) SplitText(text string) ([]string, error) {
 }
 
 func (sp MarkdownTextSplitter) flushChunk(chunks []string, currentChunk []string) ([]string, []string, error) {
-
 	// Ignore heading only chunks if the option is set and the last line in the chunk is a header
 	if sp.IgnoreHeadingOnly && strings.HasPrefix(currentChunk[len(currentChunk)-1], "#") {
 		return chunks, []string{}, nil
@@ -125,21 +122,17 @@ func (sp MarkdownTextSplitter) flushChunk(chunks []string, currentChunk []string
 
 	if chunkstr != "" && chunkstr != "\n" {
 		if sp.SecondSplitter != nil {
-
 			// Split the chunk into smaller chunks
 			splits, err := sp.SecondSplitter.SplitText(chunkstr)
 			if err != nil {
 				return chunks, []string{}, err
 			}
 
-			for _, split := range splits {
-				chunks = append(chunks, split)
-			}
+			chunks = append(chunks, splits...)
 
 			if len(splits) == 0 {
 				chunks = append(chunks, headerstr)
 			}
-
 		} else {
 			splits, err := lcgosplitter.NewRecursiveCharacter(
 				lcgosplitter.WithChunkSize(sp.ChunkSize-utf8.RuneCountInString(headerstr)),
@@ -158,7 +151,6 @@ func (sp MarkdownTextSplitter) flushChunk(chunks []string, currentChunk []string
 			if len(splits) == 0 {
 				chunks = append(chunks, headerstr)
 			}
-
 		}
 	}
 

--- a/pkg/datastore/textsplitter/markdown_basic/markdown_basic_test.go
+++ b/pkg/datastore/textsplitter/markdown_basic/markdown_basic_test.go
@@ -17,7 +17,6 @@ func TestSplitTextWithBasicMarkdown(t *testing.T) {
 }
 
 func TestSplitTextWithOptions(t *testing.T) {
-
 	md := `
 # Heading 1
 
@@ -82,5 +81,4 @@ some p under h4
 			assert.Equal(t, tc.expected, chunks)
 		})
 	}
-
 }

--- a/pkg/datastore/types/types.go
+++ b/pkg/datastore/types/types.go
@@ -6,6 +6,10 @@ import (
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
 
+const (
+	ArchivePrefix = "archive://"
+)
+
 type DocumentTransformerFunc func(context.Context, []vs.Document) ([]vs.Document, error)
 
 type DocumentTransformer interface {

--- a/pkg/index/datasets.go
+++ b/pkg/index/datasets.go
@@ -1,9 +1,60 @@
 package index
 
-import "gorm.io/gorm"
+import (
+	"context"
+	"gorm.io/gorm"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
 
 func GetDataset(db *gorm.DB, id string) (*Dataset, error) {
 	var dataset Dataset
 	err := db.First(&dataset, "id = ?", id).Error
 	return &dataset, err
+}
+
+// TODO: Index should become an interface to support this for different databases
+
+func (db *DB) ExportDatasetsToFile(ctx context.Context, path string, ids ...string) error {
+	gdb := db.gormDB.WithContext(ctx)
+
+	var datasets []Dataset
+	err := gdb.Find(&datasets, "id IN ?", ids).Error
+	if err != nil {
+		return err
+	}
+
+	slog.Debug("Exporting datasets", "ids", ids, "count", len(datasets))
+
+	finfo, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if finfo.IsDir() {
+		path = filepath.Join(path, "knowledge-export.db")
+	}
+
+	slog.Debug("Exporting datasets to file", "path", path)
+
+	ndb, err := New("sqlite://"+path, true)
+	if err != nil {
+		return err
+	}
+	if err := ndb.AutoMigrate(); err != nil {
+		return err
+	}
+	ngdb := ndb.gormDB.WithContext(ctx)
+
+	defer ndb.Close()
+
+	// fill new database with exported datasets
+	for _, dataset := range datasets {
+		if err := ngdb.Create(&dataset).Error; err != nil {
+			return err
+		}
+	}
+	ngdb.Commit()
+
+	return nil
 }

--- a/pkg/index/datasets.go
+++ b/pkg/index/datasets.go
@@ -20,7 +20,7 @@ func (db *DB) ExportDatasetsToFile(ctx context.Context, path string, ids ...stri
 	gdb := db.gormDB.WithContext(ctx)
 
 	var datasets []Dataset
-	err := gdb.Find(&datasets, "id IN ?", ids).Error
+	err := gdb.Preload("Files.Documents").Find(&datasets, "id IN ?", ids).Error
 	if err != nil {
 		return err
 	}

--- a/pkg/vectorstore/chromem/chromem.go
+++ b/pkg/vectorstore/chromem/chromem.go
@@ -156,7 +156,15 @@ func (s *Store) RemoveDocument(ctx context.Context, documentID string, collectio
 }
 
 func (s *Store) ImportCollectionsFromFile(ctx context.Context, path string, collections ...string) error {
-	return fmt.Errorf("not implemented")
+	finfo, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("couldn't stat file %q: %w", path, err)
+	}
+	if finfo.IsDir() {
+		return fmt.Errorf("path %q is a directory", path)
+	}
+	slog.Debug("Importing collections from file", "path", path)
+	return s.db.ImportFromFile(path, "", collections...)
 }
 
 func (s *Store) ExportCollectionsToFile(ctx context.Context, path string, collections ...string) error {

--- a/pkg/vectorstore/chromem/chromem.go
+++ b/pkg/vectorstore/chromem/chromem.go
@@ -6,6 +6,8 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/vectorstore/errors"
 	"log/slog"
 	"maps"
+	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -151,4 +153,19 @@ func (s *Store) RemoveDocument(ctx context.Context, documentID string, collectio
 		return fmt.Errorf("%w: %q", errors.ErrCollectionNotFound, collection)
 	}
 	return col.Delete(ctx, where, whereDocument, documentID)
+}
+
+func (s *Store) ImportCollectionsFromFile(ctx context.Context, path string, collections ...string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (s *Store) ExportCollectionsToFile(ctx context.Context, path string, collections ...string) error {
+	finfo, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("couldn't stat file %q: %w", path, err)
+	}
+	if finfo.IsDir() {
+		path = filepath.Join(path, "chromem-export.gob")
+	}
+	return s.db.ExportToFile(path, false, "", collections...)
 }

--- a/pkg/vectorstore/chromem/chromem.go
+++ b/pkg/vectorstore/chromem/chromem.go
@@ -167,5 +167,6 @@ func (s *Store) ExportCollectionsToFile(ctx context.Context, path string, collec
 	if finfo.IsDir() {
 		path = filepath.Join(path, "chromem-export.gob")
 	}
+	slog.Debug("Exporting collections to file", "path", path)
 	return s.db.ExportToFile(path, false, "", collections...)
 }

--- a/pkg/vectorstore/vectorstores.go
+++ b/pkg/vectorstore/vectorstores.go
@@ -10,4 +10,7 @@ type VectorStore interface {
 	SimilaritySearch(ctx context.Context, query string, numDocuments int, collection string) ([]Document, error) //nolint:lll
 	RemoveCollection(ctx context.Context, collection string) error
 	RemoveDocument(ctx context.Context, documentID string, collection string, where, whereDocument map[string]string) error
+
+	ImportCollectionsFromFile(ctx context.Context, path string, collections ...string) error
+	ExportCollectionsToFile(ctx context.Context, path string, collections ...string) error
 }


### PR DESCRIPTION
- `knowledge export <dataset> --output foo.zip`
- `knowledge retrieve -d <dataset> --archive foo.zip "some question"`
- `knowledge list-datasets --archive foo.zip`
- `knowledge get-dataset <dataset> --archive foo.zip`
- `knowledge import foo.zip`

Depends On (currently using fork): https://github.com/philippgille/chromem-go/pull/88


NOTE: there are quite a few rough edges and missing pieces, e.g. the server-mode version of this is not yet implemented.. we'll follow up on this in the future!