### PR TITLE
feat: new embeddings config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Knowledge API
+# GPTScript Knowledge Tool
 
 Standalone Knowledge Tool to be used with GPTScript and GPTStudio
+
+**[gptscript-ai.github.io/knowledge](https://gptscript-ai.github.io/knowledge)**
 
 ## Build
 
@@ -14,6 +16,8 @@ make build
 
 The knowledge tool can run in two modes: server and client, where client can be standalone or referring to a remote server.
 
+You can find a full gptscript-generated documentation in the [CLI documentation](./docs/cli.md).
+
 
 ### Client - Standalone
 
@@ -26,6 +30,12 @@ knowledge delete-dataset foobar
 
 ### Server & Client - Server Mode
 
+**WARNING** The server mode is not fully implemented and currently lacking some features. You're well advised to use the standalone client mode.
+
+<details>
+
+<summary>Server</summary>
+
 ```bash
 knowledge server
 ```
@@ -37,6 +47,9 @@ knowledge ingest -d foobar README.md
 knowledge retrieve -d foobar "Which filetypes are supported?"
 knowledge delete-dataset foobar
 ```
+
+</details>
+
 
 ## Supported File Types
 
@@ -64,52 +77,3 @@ Note: The examples in the `examples/` directory expect the `knowledge` binary to
 ```bash
 gptscript examples/client.gpt
 ```
-
-## Architecture & Components
-
-The knowledge tool is composed of the following components, which are all run from the same executable:
-
-- knowledge client
-  - can run in two modes:
-    - standalone ([client/standalone](./pkg/client/standalone.go)): manages its own vector and knowledge database locally
-    - server/remote ([client/default](./pkg/client/default.go)): interacts with a knowledge server over the network
-- knowledge server ([server](./pkg/server))
-  - lets you run a REST API server that interacts with the below databases, so the client is stateless and sends/receives data over the network
-- datastore ([datastore](./pkg/datastore/datastore.go))
-  - responsible for handling data ingestion and retrieval
-    - ingestion includes
-      - loading documents (extracting text)
-      - splitting text into chunks
-      - pre-processing (e.g. metadata extraction, content enrichment)
-      - requesting embeddings (part of the vectorstore implementation)
-      - storing embeddings and metadata in the vector database
-      - registering the document in the knowledge database (index)
-    - retrieval includes
-      - query embedding
-      - querying the vector database for embeddings - similarity search
-      - mapping the retrieved embeddings to document contents
-      - (optional) post-processing (e.g. filtering, sorting, summarization)
-      - returning document contents alongside their similarity scores
-  - consists of two databases:
-    - vector database ([vectorstore](./pkg/vectorstore/vectorstores.go))
-      - Current choice: [chromem-go](https://github.com/philippgille/chromem-go)
-      - used for storing and retrieving embeddings alongside the document contents
-      - the implementation is responsible for
-        - requesting the embeddings from a model (e.g. OpenAI's text-embeddings-ada-002)
-        - storing the embeddings together with metadata and document contents
-        - doing similarity searches to retrieve embeddings
-        - returning document contents alongside their similarity scores
-    - knowledge database ([index](./pkg/index/db.go)
-      - Current choice: sqlite3
-      - used for
-        - indexing knowledge bases (datasets): dataset <(1:n)> files <(1:n)> documents
-          - this is useful for deleting specific documents or files from a dataset and to get quick overviews over datasets without having to query the vector database (which holds this information in the metadata)
-        - storing knowledge base metadata and e.g. attached ingestion flows
-
-## Retrieval Flows
-
-The knowledge tool allows you to configure how sources are retrieved and how they should be treated before being returned to the caller (usually an LLM).
-
-Here's how it looks like:
-
-![Retrieval Flows](./docs/static/img/retrieval_flows.png)

--- a/docs/docs/04-configfile.md
+++ b/docs/docs/04-configfile.md
@@ -34,20 +34,29 @@ Here we try to capture all supported configuration items in one example.
 
 ```yaml
 embeddings:
-  provider: vertex # this selects one of the below providers
-  cohere:
-    apiKey: "${COHERE_API_KEY}" # environment variables are expanded when reading the config file
-    model: "embed-english-v2.0"
-  openai:
-    apiKey: "${OPENAI_API_KEY}"
-    embeddingEndpoint: "/some-custom-endpoint" # anything that's not the default /embeddings
-  vertex:
-    apiKey: "${GOOGLE_API_KEY}"
-    project: "acorn-io"
-    model: "text-embedding-004"
+  providers:
+  - name: my-cohere
+    type: cohere
+    config:
+      apiKey: "${COHERE_API_KEY}" # environment variables are expanded when reading the config file
+      model: "embed-english-v2.0"
+  - name: myopenai
+    type: openai
+    config:
+      apiKey: "${OPENAI_API_KEY}"
+      embeddingEndpoint: "/some-custom-endpoint" # anything that's not the default /embeddings
+  - name: foobar
+    type: vertex
+    config:
+      apiKey: "${GOOGLE_API_KEY}"
+      project: "acorn-io"
+      # apiEndpoint: https://us-central1-aiplatform.googleapis.com
+      model: "text-embedding-004"
 ```
 
 ### Sections
 
 - `embeddings`: See [Embedding Models](05-embedding_models.md) for more details.
-  - `provider`: May as well be set using the command line flag `--embedding-model-provider` or the environment variable `KNOW_EMBEDDING_MODEL_PROVIDER` (default: `openai`).
+  - Select a provider using the command line flag `--embedding-model-provider` or the environment variable `KNOW_EMBEDDING_MODEL_PROVIDER` (default: `openai`).
+  - **Note**: If a provider is selected but not specified in the config file, we'll assume that it's a standard provider configured via standard environment variables.
+    - E.g. you select `vertex`, but that name is not configured, so we default to `type=vertex` and use the `VERTEX_*` environment variables to configure a standard Google Vertex AI provider.

--- a/docs/docs/10-datasets/02-sharing.md
+++ b/docs/docs/10-datasets/02-sharing.md
@@ -42,7 +42,8 @@ knowledge export my-dataset --output my-dataset.zip
 
 Importing a Dataset works just fine, but there's a culprit when you want to **ingest additional content into an imported dataset**: You'll have to use the exact same embedding function as the original dataset.
 The Embedding function is part of the Vector Database implementation and defines how the content is transformed into a vector representation.
-Currently, this is defined solely based on the model provider configuration, so it's fairly simple to replicate - you just have to use the same model (`$OPENAI_EMBEDDING_MODEL`) for it to work.
+Currently, this is defined solely based on the model provider configuration, so it's fairly simple to replicate - you just have to use the exact same model usually.
+When you try ingesting into an imported dataset with a differing embedding model provider config, the tool will error out if there is a mismatch in a required config field, so you can adjust.
 
 :::
 

--- a/examples/configfiles/embedding_provider.yaml
+++ b/examples/configfiles/embedding_provider.yaml
@@ -1,13 +1,20 @@
 embeddings:
-  provider: vertex # this selects one of the below
-  cohere:
-    apiKey: "${COHERE_API_KEY}" # environment variables are expanded when reading the config file
-    model: "embed-english-v2.0"
-  openai:
-    apiKey: "${OPENAI_API_KEY}"
-    embeddingEndpoint: "/some-custom-endpoint" # anything that's not the default /embeddings
-  vertex:
-    apiKey: "${GOOGLE_API_KEY}"
-    project: "acorn-io"
-    # apiEndpoint: https://us-central1-aiplatform.googleapis.com
-    model: "text-embedding-004"
+  provider: foobar # this selects one of the below
+  providers:
+  - name: my-cohere
+    type: cohere
+    config:
+      apiKey: "${COHERE_API_KEY}" # environment variables are expanded when reading the config file
+      model: "embed-english-v2.0"
+  - name: myopenai
+    type: openai
+    config:
+      apiKey: "${OPENAI_API_KEY}"
+      embeddingEndpoint: "/some-custom-endpoint" # anything that's not the default /embeddings
+  - name: foobar
+    type: vertex
+    config:
+      apiKey: "${GOOGLE_API_KEY}"
+      project: "acorn-io"
+      # apiEndpoint: https://us-central1-aiplatform.googleapis.com
+      model: "text-embedding-004"

--- a/examples/configfiles/embedding_provider.yaml
+++ b/examples/configfiles/embedding_provider.yaml
@@ -1,5 +1,4 @@
 embeddings:
-  provider: foobar # this selects one of the below
   providers:
   - name: my-cohere
     type: cohere

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gen2brain/go-fitz v1.23.7
 	github.com/gin-gonic/gin v1.10.0
 	github.com/glebarez/sqlite v1.11.0
+	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1
 	github.com/google/uuid v1.6.0
 	github.com/hupe1980/golc v0.0.112
 	github.com/joho/godotenv v1.5.1
@@ -92,7 +93,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/go-resty/resty/v2 v2.3.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/gobwas/ws v1.2.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ type IngestPathsOpts struct {
 	Recursive        bool
 	TextSplitterOpts *textsplitter.TextSplitterOpts
 	IngestionFlows   []flows.IngestionFlow
+	CreateDataset    bool
 }
 
 type Client interface {

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -142,6 +142,7 @@ func (c *DefaultClient) IngestPaths(ctx context.Context, datasetID string, opts 
 				ModifiedAt:   finfo.ModTime(),
 			},
 			IsDuplicateFuncName: "file_metadata",
+			CreateDataset:       opts.CreateDataset,
 		}
 		if opts != nil {
 			payload.TextSplitterOpts = opts.TextSplitterOpts

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -90,6 +90,7 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 				ModifiedAt:   finfo.ModTime(),
 			},
 			IsDuplicateFunc: datastore.DedupeByFileMetadata,
+			CreateDataset:   true,
 		}
 
 		if opts != nil {

--- a/pkg/cmd/askdir.go
+++ b/pkg/cmd/askdir.go
@@ -41,6 +41,7 @@ func (s *ClientAskDir) Run(cmd *cobra.Command, args []string) error {
 		IgnoreExtensions: strings.Split(s.IgnoreExtensions, ","),
 		Concurrency:      s.Concurrency,
 		Recursive:        !s.NoRecursive,
+		CreateDataset:    true,
 	}
 
 	retrieveOpts := &datastore.RetrieveOpts{

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/client"
 	"github.com/gptscript-ai/knowledge/pkg/config"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
 	"io"
 	"os"
@@ -105,11 +104,11 @@ func (s *Client) getClient() (client.Client, error) {
 	}
 
 	if s.Server == "" || s.Server == "standalone" {
-		embeddingModelProvider, err := embeddings.GetEmbeddingsModelProvider(s.EmbeddingModelProvider, cfg.EmbeddingsConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get embeddings model provider: %w", err)
+		if s.EmbeddingModelProvider != "" {
+			cfg.EmbeddingsConfig.Provider = s.EmbeddingModelProvider
 		}
-		ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, embeddingModelProvider)
+
+		ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, cfg.EmbeddingsConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/import.go
+++ b/pkg/cmd/import.go
@@ -13,8 +13,9 @@ func (s *ClientImportDatasets) Customize(cmd *cobra.Command) {
 	cmd.Short = "Import one or more datasets from an archive (zip) (default: all datasets)"
 	cmd.Long = `Import one or more datasets from an archive (zip) (default: all datasets).
 ## IMPORTANT: Embedding functions
-   Embedding functions are not part of exported knowledge base archives, so you'll have to know the embedding function used to import the archive.
-   This primarily concerns the choice of the embeddings provider (model).
+   When someone first ingests some data into a dataset, the embedding provider configured at that time will be attached to the dataset.
+   Upon subsequent ingestion actions, the same embedding provider must be used to ensure that the embeddings are consistent.
+   Most of the times, the only field that has to be the same is the model, as that defines the dimensionality usually.
    Note: This is only relevant if you plan to add more documents to the dataset after importing it.
 `
 	cmd.Args = cobra.MinimumNArgs(1)

--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -29,6 +29,14 @@ type ClientIngestOpts struct {
 func (s *ClientIngest) Customize(cmd *cobra.Command) {
 	cmd.Use = "ingest [--dataset <dataset-id>] <path>"
 	cmd.Short = "Ingest a file/directory into a dataset"
+	cmd.Long = `Ingest a file or directory into a dataset.
+
+## Important Note
+
+The first time you ingest something into a dataset, the embedding function (model provider) you chose will be attached to that dataset.
+After that, the client must always use that same embedding function to ingest into this dataset.
+This is a constraint of the Vector Database and Similarity Search, as different models yield differently sized embedding vectors and also represent the semantics differently.
+`
 	cmd.Args = cobra.ExactArgs(1)
 }
 

--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -24,6 +24,7 @@ type ClientIngestOpts struct {
 	IgnoreExtensions string `usage:"Comma-separated list of file extensions to ignore" env:"KNOW_INGEST_IGNORE_EXTENSIONS"`
 	Concurrency      int    `usage:"Number of concurrent ingestion processes" default:"10" env:"KNOW_INGEST_CONCURRENCY"`
 	NoRecursive      bool   `usage:"Don't recursively ingest directories" default:"false" env:"KNOW_NO_INGEST_RECURSIVE"`
+	CreateDataset    bool   `usage:"Create the dataset if it doesn't exist" default:"true" env:"KNOW_INGEST_CREATE_DATASET"`
 }
 
 func (s *ClientIngest) Customize(cmd *cobra.Command) {
@@ -35,6 +36,7 @@ func (s *ClientIngest) Customize(cmd *cobra.Command) {
 
 The first time you ingest something into a dataset, the embedding function (model provider) you chose will be attached to that dataset.
 After that, the client must always use that same embedding function to ingest into this dataset.
+Usually, this only concerns the choice of the model, as that commonly defines the embedding dimensionality.
 This is a constraint of the Vector Database and Similarity Search, as different models yield differently sized embedding vectors and also represent the semantics differently.
 `
 	cmd.Args = cobra.ExactArgs(1)
@@ -54,6 +56,7 @@ func (s *ClientIngest) Run(cmd *cobra.Command, args []string) error {
 		Concurrency:      s.Concurrency,
 		Recursive:        !s.NoRecursive,
 		TextSplitterOpts: &s.TextSplitterOpts,
+		CreateDataset:    s.CreateDataset,
 	}
 
 	if s.FlowsFile != "" {

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	"github.com/spf13/cobra"
 	"log/slog"
 	"os/signal"
@@ -42,11 +43,12 @@ func (s *Server) Run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	if s.EmbeddingModelProvider != "" {
-		cfg.EmbeddingsConfig.Provider = s.EmbeddingModelProvider
+	provider, err := embeddings.GetSelectedEmbeddingsModelProvider(s.EmbeddingModelProvider, cfg.EmbeddingsConfig)
+	if err != nil {
+		return err
 	}
 
-	ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, cfg.EmbeddingsConfig)
+	ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, provider)
 	if err != nil {
 		return fmt.Errorf("failed to initialize datastore: %w", err)
 	}

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	"github.com/spf13/cobra"
 	"log/slog"
 	"os/signal"
@@ -43,12 +42,11 @@ func (s *Server) Run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	embeddingModelProvider, err := embeddings.GetEmbeddingsModelProvider(s.EmbeddingModelProvider, cfg.EmbeddingsConfig)
-	if err != nil {
-		return fmt.Errorf("failed to get embeddings model provider: %w", err)
+	if s.EmbeddingModelProvider != "" {
+		cfg.EmbeddingsConfig.Provider = s.EmbeddingModelProvider
 	}
 
-	ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, embeddingModelProvider)
+	ds, err := datastore.NewDatastore(s.DSN, s.AutoMigrate == "true", s.VectorDBConfig.VectorDBPath, cfg.EmbeddingsConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize datastore: %w", err)
 	}

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	"github.com/spf13/cobra"
+	"log/slog"
 	"os/signal"
 	"syscall"
 
@@ -25,7 +26,17 @@ type Server struct {
 	config.VectorDBConfig
 }
 
+func (s *Server) Customize(cmd *cobra.Command) {
+	cmd.Use = "server"
+	cmd.Short = "Run the Knowledge API Server"
+	cmd.Long = `Run the Knowledge API Server.`
+
+	cmd.Hidden = true
+}
+
 func (s *Server) Run(cmd *cobra.Command, _ []string) error {
+
+	slog.Warn("The knowledge server is underdeveloped and lacking behind the standalone client right now, use at your own risk!") // FIXME: Bring the server on par with the standalone client and drop this warning
 
 	cfg, err := config.LoadConfig(s.ConfigFile)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,14 +2,6 @@ package config
 
 import (
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/cohere"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/jina"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/localai"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/mistral"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/mixedbread"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/ollama"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/openai"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/vertex"
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/rawbytes"
@@ -23,15 +15,14 @@ type Config struct {
 }
 
 type EmbeddingsConfig struct {
-	Provider   string
-	OpenAI     openai.OpenAIConfig                    `koanf:"openai" json:"openai,omitempty"`
-	Cohere     cohere.EmbeddingModelProviderCohere    `koanf:"cohere" json:"cohere,omitempty"`
-	Vertex     vertex.EmbeddingProviderVertex         `koanf:"vertex" json:"vertex,omitempty"`
-	Jina       jina.EmbeddingProviderJina             `koanf:"jina" json:"jina,omitempty"`
-	Mistral    mistral.EmbeddingProviderMistral       `koanf:"mistral" json:"mistral,omitempty"`
-	Mixedbread mixedbread.EmbeddingProviderMixedbread `koanf:"mixedbread" json:"mixedbread,omitempty"`
-	LocalAI    localai.EmbeddingProviderLocalAI       `koanf:"localai" json:"localai,omitempty"`
-	Ollama     ollama.EmbeddingProviderOllama         `koanf:"ollama" json:"ollama,omitempty"`
+	Provider  string                     `koanf:"provider" json:"provider,omitempty" mapstructure:"provider"`
+	Providers []EmbeddingsProviderConfig `koanf:"providers" json:"providers,omitempty" mapstructure:"providers"`
+}
+
+type EmbeddingsProviderConfig struct {
+	Name   string         `koanf:"name" json:"name,omitempty" mapstructure:"name"`
+	Type   string         `koanf:"type" json:"type,omitempty" mapstructure:"type"`
+	Config map[string]any `koanf:"config" json:"config,omitempty" mapstructure:"config"`
 }
 
 type DatabaseConfig struct {
@@ -77,4 +68,14 @@ func LoadConfig(configFile string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func (ec *EmbeddingsConfig) RemoveUnselected() {
+	keep := make([]EmbeddingsProviderConfig, 1)
+	for _, p := range ec.Providers {
+		if p.Name == ec.Provider {
+			keep[0] = p
+		}
+	}
+	ec.Providers = keep
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,6 @@ type Config struct {
 }
 
 type EmbeddingsConfig struct {
-	Provider  string                     `koanf:"provider" json:"provider,omitempty" mapstructure:"provider"`
 	Providers []EmbeddingsProviderConfig `koanf:"providers" json:"providers,omitempty" mapstructure:"providers"`
 }
 
@@ -70,10 +69,10 @@ func LoadConfig(configFile string) (*Config, error) {
 	return cfg, nil
 }
 
-func (ec *EmbeddingsConfig) RemoveUnselected() {
+func (ec *EmbeddingsConfig) RemoveUnselected(selected string) {
 	keep := make([]EmbeddingsProviderConfig, 1)
 	for _, p := range ec.Providers {
-		if p.Name == ec.Provider {
+		if p.Name == selected {
 			keep[0] = p
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestEmbeddingsConfig_ClearUnselected(t *testing.T) {
 	ec := &EmbeddingsConfig{
-		Provider: "openai",
 		Providers: []EmbeddingsProviderConfig{
 			{
 				Name: "openai",
@@ -29,7 +28,7 @@ func TestEmbeddingsConfig_ClearUnselected(t *testing.T) {
 
 	require.Len(t, ec.Providers, 2)
 
-	ec.RemoveUnselected()
+	ec.RemoveUnselected("openai")
 
 	require.Len(t, ec.Providers, 1)
 	require.Equal(t, "openai", ec.Providers[0].Name)
@@ -41,11 +40,10 @@ func TestEmbeddingsConfig_ClearUnselected(t *testing.T) {
 			"model": "some-model",
 		},
 	})
-	ec.Provider = "cohere"
 
 	require.Len(t, ec.Providers, 2)
 
-	ec.RemoveUnselected()
+	ec.RemoveUnselected("cohere")
 
 	require.Len(t, ec.Providers, 1)
 	require.Equal(t, "cohere", ec.Providers[0].Name)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestEmbeddingsConfig_ClearUnselected(t *testing.T) {
+	ec := &EmbeddingsConfig{
+		Provider: "openai",
+		Providers: []EmbeddingsProviderConfig{
+			{
+				Name: "openai",
+				Type: "openai",
+				Config: map[string]any{
+					"baseURL": "foo.bar.com",
+					"apiKey":  "123456",
+				},
+			},
+			{
+				Name: "cohere",
+				Type: "cohere",
+				Config: map[string]any{
+					"model": "some-model",
+				},
+			},
+		},
+	}
+
+	require.Len(t, ec.Providers, 2)
+
+	ec.RemoveUnselected()
+
+	require.Len(t, ec.Providers, 1)
+	require.Equal(t, "openai", ec.Providers[0].Name)
+
+	ec.Providers = append(ec.Providers, EmbeddingsProviderConfig{
+		Name: "cohere",
+		Type: "cohere",
+		Config: map[string]any{
+			"model": "some-model",
+		},
+	})
+	ec.Provider = "cohere"
+
+	require.Len(t, ec.Providers, 2)
+
+	ec.RemoveUnselected()
+
+	require.Len(t, ec.Providers, 1)
+	require.Equal(t, "cohere", ec.Providers[0].Name)
+
+}

--- a/pkg/datastore/dataset.go
+++ b/pkg/datastore/dataset.go
@@ -102,13 +102,16 @@ func (s *Datastore) UpdateDataset(ctx context.Context, updatedDataset index.Data
 		origDS.UpdateMetadata(updatedDataset.Metadata)
 	}
 
-	// Check if there is any other non-null field in the updatedDataset
+	if updatedDataset.EmbeddingsConfig != nil {
+		origDS.EmbeddingsConfig = updatedDataset.EmbeddingsConfig
+	}
 
+	// Check if there is any other non-null field in the updatedDataset
 	if updatedDataset.Files != nil {
 		return origDS, fmt.Errorf("files cannot be updated")
 	}
 
-	slog.Debug("Updating dataset", "id", updatedDataset.ID, "metadata", updatedDataset.Metadata)
+	slog.Debug("Updating dataset", "id", updatedDataset.ID, "metadata", updatedDataset.Metadata, "embeddingsConfig", updatedDataset.EmbeddingsConfig)
 
 	return origDS, s.Index.UpdateDataset(ctx, *origDS)
 }

--- a/pkg/datastore/dataset.go
+++ b/pkg/datastore/dataset.go
@@ -102,8 +102,8 @@ func (s *Datastore) UpdateDataset(ctx context.Context, updatedDataset index.Data
 		origDS.UpdateMetadata(updatedDataset.Metadata)
 	}
 
-	if updatedDataset.EmbeddingsConfig != nil {
-		origDS.EmbeddingsConfig = updatedDataset.EmbeddingsConfig
+	if updatedDataset.EmbeddingsProviderConfig != nil {
+		origDS.EmbeddingsProviderConfig = updatedDataset.EmbeddingsProviderConfig
 	}
 
 	// Check if there is any other non-null field in the updatedDataset
@@ -111,7 +111,7 @@ func (s *Datastore) UpdateDataset(ctx context.Context, updatedDataset index.Data
 		return origDS, fmt.Errorf("files cannot be updated")
 	}
 
-	slog.Debug("Updating dataset", "id", updatedDataset.ID, "metadata", updatedDataset.Metadata, "embeddingsConfig", updatedDataset.EmbeddingsConfig)
+	slog.Debug("Updating dataset", "id", updatedDataset.ID, "metadata", updatedDataset.Metadata, "embeddingsConfig", updatedDataset.EmbeddingsProviderConfig)
 
 	return origDS, s.Index.UpdateDataset(ctx, *origDS)
 }

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/gptscript-ai/knowledge/pkg/config"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	etypes "github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/types"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
 	"github.com/gptscript-ai/knowledge/pkg/output"
@@ -68,13 +67,7 @@ func GetDatastorePaths(dsn, vectordbPath string) (string, string, bool, error) {
 	return dsn, vectordbPath, isArchive, nil
 }
 
-func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingsConfig config.EmbeddingsConfig) (*Datastore, error) {
-
-	embeddingsConfig.RemoveUnselected()
-	embeddingProvider, err := embeddings.GetSelectedEmbeddingsModelProvider(embeddingsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get embeddings model provider: %w", err)
-	}
+func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingProvider etypes.EmbeddingModelProvider) (*Datastore, error) {
 
 	dsn, vectorDBPath, isArchive, err := GetDatastorePaths(dsn, vectorDBPath)
 	if err != nil {
@@ -114,7 +107,6 @@ func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingsC
 	ds := &Datastore{
 		Index:                  idx,
 		Vectorstore:            chromem.New(vsdb, embeddingFunc),
-		EmbeddingConfig:        embeddingsConfig,
 		EmbeddingModelProvider: embeddingProvider,
 	}
 

--- a/pkg/datastore/embeddings/cohere/cohere.go
+++ b/pkg/datastore/embeddings/cohere/cohere.go
@@ -10,25 +10,24 @@ import (
 const EmbeddingModelProviderCohereName string = "cohere"
 
 type EmbeddingModelProviderCohere struct {
-	APIKey string `env:"COHERE_API_KEY" koanf:"apiKey"`
-	Model  string `env:"COHERE_MODEL" koanf:"model"`
+	APIKey string `env:"COHERE_API_KEY" koanf:"apiKey" export:"false"`
+	Model  string `env:"COHERE_MODEL" koanf:"model" export:"required"`
 }
 
 func (p *EmbeddingModelProviderCohere) Name() string {
 	return EmbeddingModelProviderCohereName
 }
 
-func New(c EmbeddingModelProviderCohere) (*EmbeddingModelProviderCohere, error) {
-
-	if err := load.FillConfigEnv("COHERE_", &c); err != nil {
-		return nil, fmt.Errorf("failed to fill Cohere config from environment: %w", err)
+func (p *EmbeddingModelProviderCohere) Configure() error {
+	if err := load.FillConfigEnv("COHERE_", p); err != nil {
+		return fmt.Errorf("failed to fill Cohere config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill Cohere defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill Cohere defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingModelProviderCohere) fillDefaults() error {

--- a/pkg/datastore/embeddings/embeddings.go
+++ b/pkg/datastore/embeddings/embeddings.go
@@ -1,6 +1,7 @@
 package embeddings
 
 import (
+	"errors"
 	"fmt"
 	"github.com/gptscript-ai/knowledge/pkg/config"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/cohere"
@@ -12,33 +13,187 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/openai"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/types"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/vertex"
+	"github.com/mitchellh/mapstructure"
+	"reflect"
+	"strings"
 )
 
-func GetEmbeddingsModelProvider(name string, embeddingsConfig config.EmbeddingsConfig) (types.EmbeddingModelProvider, error) {
-
-	if name == "" {
-		name = embeddingsConfig.Provider
+func GetSelectedEmbeddingsModelProvider(embeddingsConfig config.EmbeddingsConfig) (types.EmbeddingModelProvider, error) {
+	provider, providerCfg, err := GetEmbeddingsModelProviderStruct(embeddingsConfig)
+	if err != nil {
+		return nil, err
 	}
-	embeddingsConfig.Provider = name
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "koanf",
+		Result:  provider,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create decoder: %w", err)
+	}
+	if err := decoder.Decode(providerCfg.Config); err != nil {
+		return nil, fmt.Errorf("failed to decode provider config: %w", err)
+	}
 
-	switch name {
+	if err := provider.Configure(); err != nil {
+		return nil, fmt.Errorf("failed to configure provider: %w", err)
+	}
+
+	return provider, nil
+
+}
+
+func GetProviderConfig(providerType string) (types.EmbeddingModelProvider, error) {
+	switch strings.ToLower(providerType) {
 	case openai.EmbeddingModelProviderOpenAIName:
-		return openai.New(openai.EmbeddingModelProviderOpenAI{OpenAIConfig: embeddingsConfig.OpenAI})
+		return &openai.EmbeddingModelProviderOpenAI{}, nil
 	case cohere.EmbeddingModelProviderCohereName:
-		return cohere.New(embeddingsConfig.Cohere)
+		return &cohere.EmbeddingModelProviderCohere{}, nil
 	case vertex.EmbeddingProviderVertexName:
-		return vertex.New(embeddingsConfig.Vertex)
+		return &vertex.EmbeddingProviderVertex{}, nil
 	case jina.EmbeddingProviderJinaName:
-		return jina.New(embeddingsConfig.Jina)
+		return &jina.EmbeddingProviderJina{}, nil
 	case mistral.EmbeddingProviderMistralName:
-		return mistral.New(embeddingsConfig.Mistral)
+		return &mistral.EmbeddingProviderMistral{}, nil
 	case mixedbread.EmbeddingProviderMixedbreadName:
-		return mixedbread.New(embeddingsConfig.Mixedbread)
+		return &mixedbread.EmbeddingProviderMixedbread{}, nil
 	case localai.EmbeddingProviderLocalAIName:
-		return localai.New(embeddingsConfig.LocalAI)
+		return &localai.EmbeddingProviderLocalAI{}, nil
 	case ollama.EmbeddingProviderOllamaName:
-		return ollama.New(embeddingsConfig.Ollama)
+		return &ollama.EmbeddingProviderOllama{}, nil
 	default:
-		return nil, fmt.Errorf("unknown embedding model provider: %q", name)
+		return nil, fmt.Errorf("unknown embedding model provider %q", providerType)
 	}
+}
+
+func FindProviderConfig(name string, providers []config.EmbeddingsProviderConfig) *config.EmbeddingsProviderConfig {
+	for _, p := range providers {
+		if p.Name == name {
+			return &p
+		}
+	}
+	return nil
+}
+
+func GetEmbeddingsModelProviderStruct(embeddingsConfig config.EmbeddingsConfig) (types.EmbeddingModelProvider, *config.EmbeddingsProviderConfig, error) {
+
+	providerCfg := FindProviderConfig(embeddingsConfig.Provider, embeddingsConfig.Providers)
+	if providerCfg == nil {
+		// no config with that name exists, so we assume the name is the type
+		providerCfg = &config.EmbeddingsProviderConfig{
+			Name: embeddingsConfig.Provider,
+			Type: embeddingsConfig.Provider,
+		}
+	}
+
+	provider, err := GetProviderConfig(providerCfg.Type)
+	if err != nil {
+		return nil, providerCfg, err
+	}
+
+	return provider, providerCfg, nil
+}
+
+func ExportConfig(c any) (any, error) {
+	v := reflect.ValueOf(c)
+
+	// Check if input is a pointer
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil, errors.New("input must be a non-nil pointer")
+		}
+		v = v.Elem() // Dereference the pointer to get the actual value
+	}
+
+	// Ensure we're working with a struct
+	if v.Kind() != reflect.Struct {
+		return nil, errors.New("input must be a struct or a pointer to a struct")
+	}
+
+	// Create a new instance of the struct type
+	result := reflect.New(v.Type()).Elem()
+
+	// Iterate over the struct fields
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := v.Type().Field(i)
+
+		// Get the export tag value
+		exportTag := fieldType.Tag.Get("export")
+
+		// Handle the "false" export tag
+		if exportTag == "false" {
+			continue
+		}
+
+		// Handle nested structs by calling ExportConfig recursively
+		if field.Kind() == reflect.Struct {
+			n, err := ExportConfig(field.Addr().Interface())
+			if err != nil {
+				return nil, err
+			}
+			result.Field(i).Set(reflect.ValueOf(n).Elem())
+			continue
+		}
+
+		// Handle the "required" export tag
+		if exportTag == "required" && field.IsZero() {
+			return nil, fmt.Errorf("field %q is required", fieldType.Name)
+		}
+
+		// Copy the field value to the result
+		result.Field(i).Set(field)
+	}
+
+	// Return the result as a pointer if the original input was a pointer
+	if reflect.ValueOf(c).Kind() == reflect.Ptr {
+		return result.Addr().Interface(), nil
+	}
+
+	return result.Interface(), nil
+}
+
+func CompareRequiredFields(a, b any) error {
+	va := reflect.ValueOf(a)
+	vb := reflect.ValueOf(b)
+
+	// Ensure both inputs are pointers or structs
+	if va.Kind() == reflect.Ptr {
+		if va.IsNil() {
+			return errors.New("first input must be a non-nil pointer or a struct")
+		}
+		va = va.Elem()
+	}
+
+	if vb.Kind() == reflect.Ptr {
+		if vb.IsNil() {
+			return errors.New("second input must be a non-nil pointer or a struct")
+		}
+		vb = vb.Elem()
+	}
+
+	if va.Kind() != reflect.Struct || vb.Kind() != reflect.Struct {
+		return errors.New("both inputs must be structs or pointers to structs")
+	}
+
+	// Iterate over the fields of A
+	for i := 0; i < va.NumField(); i++ {
+		fieldA := va.Field(i)
+		fieldTypeA := va.Type().Field(i)
+
+		exportTag := fieldTypeA.Tag.Get("export")
+		if exportTag == "required" {
+			// Get the corresponding field in B
+			fieldB := vb.FieldByName(fieldTypeA.Name)
+			if !fieldB.IsValid() {
+				return fmt.Errorf("field %q is missing in the second struct", fieldTypeA.Name)
+			}
+
+			// Check for equality
+			if !reflect.DeepEqual(fieldA.Interface(), fieldB.Interface()) {
+				return fmt.Errorf("field %q does not match: %v != %v", fieldTypeA.Name, fieldA.Interface(), fieldB.Interface())
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/datastore/embeddings/embeddings_test.go
+++ b/pkg/datastore/embeddings/embeddings_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestLoadConfOpenAI(t *testing.T) {
-
 	// Unset the OPENAI_API_KEY env var so test passes even if it's set in the system env
 	originalEnv := os.Getenv("OPENAI_API_KEY")
 	defer os.Setenv("OPENAI_API_KEY", originalEnv)
@@ -25,14 +24,15 @@ func TestLoadConfOpenAI(t *testing.T) {
 	cfg, err := config.LoadConfig(configFile)
 	require.NoError(t, err)
 
-	p, err := GetEmbeddingsModelProvider("openai", cfg.EmbeddingsConfig)
+	cfg.EmbeddingsConfig.Provider = "openai"
+	p, err := GetSelectedEmbeddingsModelProvider(cfg.EmbeddingsConfig)
 	require.NoError(t, err)
 	require.Equal(t, "openai", p.Name())
 
 	t.Logf("Provider: %s", p.Name())
 	t.Logf("Config: %#v", p.Config())
 
-	conf := p.Config().(openai.OpenAIConfig)
+	conf := p.Config().(*openai.EmbeddingModelProviderOpenAI)
 
 	assert.Equal(t, "https://foo.bar.spam", conf.BaseURL) // this is in config and env, so env should take precedence
 	assert.Equal(t, "sk-1234567890abcdef", conf.APIKey)   // this should come from config
@@ -46,7 +46,8 @@ func TestLoadConfVertex(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load the configuration
-	p, err := GetEmbeddingsModelProvider("vertex", cfg.EmbeddingsConfig)
+	cfg.EmbeddingsConfig.Provider = "vertex"
+	p, err := GetSelectedEmbeddingsModelProvider(cfg.EmbeddingsConfig)
 	require.NoError(t, err)
 	require.Equal(t, "vertex", p.Name())
 
@@ -56,4 +57,84 @@ func TestLoadConfVertex(t *testing.T) {
 
 	require.Equal(t, "foo-embedding-001", conf.Model)
 	require.Equal(t, "foo-project", conf.Project)
+}
+
+func TestExportConfigWithValidStruct(t *testing.T) {
+	type Config struct {
+		Field1 string `export:"true"`
+		Field2 int    `export:"true"`
+		Field3 bool   `export:"false"`
+	}
+
+	input := &Config{
+		Field1: "value",
+		Field2: 42,
+		Field3: true,
+	}
+
+	expected := &Config{
+		Field1: "value",
+		Field2: 42,
+		Field3: false,
+	}
+
+	result, err := ExportConfig(input)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestExportConfigWithNestedStruct(t *testing.T) {
+	type Nested struct {
+		InnerField string `export:"true"`
+	}
+
+	type Config struct {
+		Field1 string `export:"true"`
+		Nested Nested `export:"true"`
+	}
+
+	input := &Config{
+		Field1: "value",
+		Nested: Nested{
+			InnerField: "inner value",
+		},
+	}
+
+	expected := &Config{
+		Field1: "value",
+		Nested: Nested{
+			InnerField: "inner value",
+		},
+	}
+
+	result, err := ExportConfig(input)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestExportConfigWithRequiredField(t *testing.T) {
+	type Config struct {
+		Field1 string `export:"required"`
+		Field2 int    `export:"true"`
+	}
+
+	input := &Config{
+		Field2: 42,
+	}
+
+	_, err := ExportConfig(input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "\"Field1\" is required")
+}
+
+func TestExportConfigWithNilPointer(t *testing.T) {
+	type Config struct {
+		Field1 *string `export:"true"`
+	}
+
+	var input *Config
+
+	_, err := ExportConfig(input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input must be a non-nil pointe")
 }

--- a/pkg/datastore/embeddings/embeddings_test.go
+++ b/pkg/datastore/embeddings/embeddings_test.go
@@ -24,8 +24,7 @@ func TestLoadConfOpenAI(t *testing.T) {
 	cfg, err := config.LoadConfig(configFile)
 	require.NoError(t, err)
 
-	cfg.EmbeddingsConfig.Provider = "openai"
-	p, err := GetSelectedEmbeddingsModelProvider(cfg.EmbeddingsConfig)
+	p, err := GetSelectedEmbeddingsModelProvider("openai", cfg.EmbeddingsConfig)
 	require.NoError(t, err)
 	require.Equal(t, "openai", p.Name())
 
@@ -46,8 +45,7 @@ func TestLoadConfVertex(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load the configuration
-	cfg.EmbeddingsConfig.Provider = "vertex"
-	p, err := GetSelectedEmbeddingsModelProvider(cfg.EmbeddingsConfig)
+	p, err := GetSelectedEmbeddingsModelProvider("vertex", cfg.EmbeddingsConfig)
 	require.NoError(t, err)
 	require.Equal(t, "vertex", p.Name())
 

--- a/pkg/datastore/embeddings/jina/jina.go
+++ b/pkg/datastore/embeddings/jina/jina.go
@@ -9,8 +9,8 @@ import (
 )
 
 type EmbeddingProviderJina struct {
-	APIKey string `koanf:"apiKey" env:"JINA_API_KEY"`
-	Model  string `koanf:"model" env:"JINA_MODEL"`
+	APIKey string `koanf:"apiKey" env:"JINA_API_KEY" export:"false"`
+	Model  string `koanf:"model" env:"JINA_MODEL" export:"required"`
 }
 
 const EmbeddingProviderJinaName = "jina"
@@ -19,17 +19,16 @@ func (p *EmbeddingProviderJina) Name() string {
 	return EmbeddingProviderJinaName
 }
 
-func New(c EmbeddingProviderJina) (*EmbeddingProviderJina, error) {
-
-	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderJinaName), &c); err != nil {
-		return nil, fmt.Errorf("failed to fill Jina config from environment: %w", err)
+func (p *EmbeddingProviderJina) Configure() error {
+	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderJinaName), &p); err != nil {
+		return fmt.Errorf("failed to fill Jina config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill Jina defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill Jina defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingProviderJina) fillDefaults() error {

--- a/pkg/datastore/embeddings/load/load.go
+++ b/pkg/datastore/embeddings/load/load.go
@@ -11,7 +11,6 @@ var k = koanf.New(".")
 // FillConfigEnv fills the given struct with values from a config file and environment variables.
 // The envPrefix parameter is used to prefix environment variables.
 func FillConfigEnv(envPrefix string, cfg interface{}) error {
-
 	// Load environment variables and override config file values
 	if err := k.Load(env.Provider(envPrefix, ".", func(s string) string { return s }), nil); err != nil {
 		return fmt.Errorf("error loading environment variables: %w", err)

--- a/pkg/datastore/embeddings/localai/localai.go
+++ b/pkg/datastore/embeddings/localai/localai.go
@@ -9,7 +9,7 @@ import (
 )
 
 type EmbeddingProviderLocalAI struct {
-	Model string `koanf:"model" env:"LOCALAI_MODEL"`
+	Model string `koanf:"model" env:"LOCALAI_MODEL" export:"required"`
 }
 
 const EmbeddingProviderLocalAIName = "localai"
@@ -18,17 +18,16 @@ func (p *EmbeddingProviderLocalAI) Name() string {
 	return EmbeddingProviderLocalAIName
 }
 
-func New(c EmbeddingProviderLocalAI) (*EmbeddingProviderLocalAI, error) {
-
-	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderLocalAIName), &c); err != nil {
-		return nil, fmt.Errorf("failed to fill LocalAI config from environment: %w", err)
+func (p *EmbeddingProviderLocalAI) Configure() error {
+	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderLocalAIName), &p); err != nil {
+		return fmt.Errorf("failed to fill LocalAI config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill LocalAI defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill LocalAI defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingProviderLocalAI) fillDefaults() error {

--- a/pkg/datastore/embeddings/mistral/mistral.go
+++ b/pkg/datastore/embeddings/mistral/mistral.go
@@ -9,7 +9,8 @@ import (
 )
 
 type EmbeddingProviderMistral struct {
-	APIKey string `koanf:"apiKey" env:"MISTRAL_API_KEY"`
+	APIKey string `koanf:"apiKey" env:"MISTRAL_API_KEY" export:"false"`
+	Model  string `koanf:"model" env:"MISTRAL_MODEL" export:"required"`
 }
 
 const EmbeddingProviderMistralName = "mistral"
@@ -18,21 +19,22 @@ func (p *EmbeddingProviderMistral) Name() string {
 	return EmbeddingProviderMistralName
 }
 
-func New(c EmbeddingProviderMistral) (*EmbeddingProviderMistral, error) {
-
-	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderMistralName), &c); err != nil {
-		return nil, fmt.Errorf("failed to fill Mistral config from environment: %w", err)
+func (p *EmbeddingProviderMistral) Configure() error {
+	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderMistralName), &p); err != nil {
+		return fmt.Errorf("failed to fill Mistral config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill Mistral defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill Mistral defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingProviderMistral) fillDefaults() error {
-	defaultCfg := EmbeddingProviderMistral{}
+	defaultCfg := EmbeddingProviderMistral{
+		Model: "mistral-embed",
+	}
 
 	if err := mergo.Merge(p, defaultCfg); err != nil {
 		return fmt.Errorf("failed to merge Mistral config: %w", err)

--- a/pkg/datastore/embeddings/mixedbread/mixedbread.go
+++ b/pkg/datastore/embeddings/mixedbread/mixedbread.go
@@ -9,8 +9,8 @@ import (
 )
 
 type EmbeddingProviderMixedbread struct {
-	APIKey string `koanf:"apiKey" env:"MIXEDBREAD_API_KEY"`
-	Model  string `koanf:"model" env:"MIXEDBREAD_MODEL"`
+	APIKey string `koanf:"apiKey" env:"MIXEDBREAD_API_KEY" export:"false"`
+	Model  string `koanf:"model" env:"MIXEDBREAD_MODEL" export:"required"`
 }
 
 const EmbeddingProviderMixedbreadName = "mixedbread"
@@ -19,17 +19,16 @@ func (p *EmbeddingProviderMixedbread) Name() string {
 	return EmbeddingProviderMixedbreadName
 }
 
-func New(c EmbeddingProviderMixedbread) (*EmbeddingProviderMixedbread, error) {
-
-	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderMixedbreadName), &c); err != nil {
-		return nil, fmt.Errorf("failed to fill Mixedbread config from environment: %w", err)
+func (p *EmbeddingProviderMixedbread) Configure() error {
+	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderMixedbreadName), &p); err != nil {
+		return fmt.Errorf("failed to fill Mixedbread config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill Mixedbread defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill Mixedbread defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingProviderMixedbread) fillDefaults() error {

--- a/pkg/datastore/embeddings/ollama/ollama.go
+++ b/pkg/datastore/embeddings/ollama/ollama.go
@@ -10,7 +10,7 @@ import (
 
 type EmbeddingProviderOllama struct {
 	BaseURL string `koanf:"baseURL" env:"OLLAMA_BASE_URL"`
-	Model   string `koanf:"model" env:"OLLAMA_MODEL"`
+	Model   string `koanf:"model" env:"OLLAMA_MODEL" export:"required"`
 }
 
 const EmbeddingProviderOllamaName = "ollama"
@@ -19,17 +19,16 @@ func (p *EmbeddingProviderOllama) Name() string {
 	return EmbeddingProviderOllamaName
 }
 
-func New(c EmbeddingProviderOllama) (*EmbeddingProviderOllama, error) {
-
-	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderOllamaName), &c); err != nil {
-		return nil, fmt.Errorf("failed to fill Ollama config from environment: %w", err)
+func (p *EmbeddingProviderOllama) Configure() error {
+	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderOllamaName), &p); err != nil {
+		return fmt.Errorf("failed to fill Ollama config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill Ollama defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill Ollama defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingProviderOllama) fillDefaults() error {

--- a/pkg/datastore/embeddings/openai/openai.go
+++ b/pkg/datastore/embeddings/openai/openai.go
@@ -13,18 +13,29 @@ import (
 const EmbeddingModelProviderOpenAIName string = "openai"
 
 type EmbeddingModelProviderOpenAI struct {
-	OpenAIConfig
-}
-
-type OpenAIConfig struct {
 	BaseURL           string            `usage:"OpenAI API base" default:"https://api.openai.com/v1" env:"OPENAI_BASE_URL" koanf:"baseURL"`
-	APIKey            string            `usage:"OpenAI API key (not required if used with clicky-chats)" default:"sk-foo" env:"OPENAI_API_KEY" koanf:"apiKey"`
+	APIKey            string            `usage:"OpenAI API key (not required if used with clicky-chats)" default:"sk-foo" env:"OPENAI_API_KEY" koanf:"apiKey" mapstructure:"apiKey" export:"false"`
 	Model             string            `usage:"OpenAI model" default:"gpt-4" env:"OPENAI_MODEL" koanf:"openai-model"`
-	EmbeddingModel    string            `usage:"OpenAI Embedding model" default:"text-embedding-ada-002" env:"OPENAI_EMBEDDING_MODEL" koanf:"embeddingModel"`
+	EmbeddingModel    string            `usage:"OpenAI Embedding model" default:"text-embedding-ada-002" env:"OPENAI_EMBEDDING_MODEL" koanf:"embeddingModel" export:"required"`
 	EmbeddingEndpoint string            `usage:"OpenAI Embedding endpoint" default:"/embeddings" env:"OPENAI_EMBEDDING_ENDPOINT" koanf:"embeddingEndpoint"`
 	APIVersion        string            `usage:"OpenAI API version (for Azure)" default:"2024-02-01" env:"OPENAI_API_VERSION" koanf:"apiVersion"`
 	APIType           string            `usage:"OpenAI API type (OPEN_AI, AZURE, AZURE_AD, ...)" default:"OPEN_AI" env:"OPENAI_API_TYPE" koanf:"apiType"`
 	AzureOpenAIConfig AzureOpenAIConfig `koanf:"azure"`
+}
+
+type OpenAIConfig struct {
+	BaseURL           string            `usage:"OpenAI API base" default:"https://api.openai.com/v1" env:"OPENAI_BASE_URL" koanf:"baseURL"`
+	APIKey            string            `usage:"OpenAI API key (not required if used with clicky-chats)" default:"sk-foo" env:"OPENAI_API_KEY" koanf:"apiKey" mapstructure:"apiKey" export:"false"`
+	Model             string            `usage:"OpenAI model" default:"gpt-4" env:"OPENAI_MODEL" koanf:"openai-model"`
+	EmbeddingModel    string            `usage:"OpenAI Embedding model" default:"text-embedding-ada-002" env:"OPENAI_EMBEDDING_MODEL" koanf:"embeddingModel" export:"required"`
+	EmbeddingEndpoint string            `usage:"OpenAI Embedding endpoint" default:"/embeddings" env:"OPENAI_EMBEDDING_ENDPOINT" koanf:"embeddingEndpoint"`
+	APIVersion        string            `usage:"OpenAI API version (for Azure)" default:"2024-02-01" env:"OPENAI_API_VERSION" koanf:"apiVersion"`
+	APIType           string            `usage:"OpenAI API type (OPEN_AI, AZURE, AZURE_AD, ...)" default:"OPEN_AI" env:"OPENAI_API_TYPE" koanf:"apiType"`
+	AzureOpenAIConfig AzureOpenAIConfig `koanf:"azure"`
+}
+
+func (o OpenAIConfig) Name() string {
+	return EmbeddingModelProviderOpenAIName
 }
 
 type AzureOpenAIConfig struct {
@@ -35,17 +46,16 @@ func (p *EmbeddingModelProviderOpenAI) Name() string {
 	return EmbeddingModelProviderOpenAIName
 }
 
-func New(c EmbeddingModelProviderOpenAI) (*EmbeddingModelProviderOpenAI, error) {
-
-	if err := load.FillConfigEnv("OPENAI_", &c.OpenAIConfig); err != nil {
-		return nil, fmt.Errorf("failed to fill OpenAI config from environment: %w", err)
+func (p *EmbeddingModelProviderOpenAI) Configure() error {
+	if err := load.FillConfigEnv("OPENAI_", &p); err != nil {
+		return fmt.Errorf("failed to fill OpenAI config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill OpenAI defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill OpenAI defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingModelProviderOpenAI) fillDefaults() error {
@@ -53,7 +63,7 @@ func (p *EmbeddingModelProviderOpenAI) fillDefaults() error {
 		Deployment: "",
 	}
 
-	defaultConfig := OpenAIConfig{
+	defaultConfig := EmbeddingModelProviderOpenAI{
 		BaseURL:           "https://api.openai.com/v1",
 		APIKey:            "sk-foo",
 		Model:             "gpt-4",
@@ -64,12 +74,10 @@ func (p *EmbeddingModelProviderOpenAI) fillDefaults() error {
 		AzureOpenAIConfig: defaultAzureOpenAIConfig,
 	}
 
-	err := mergo.Merge(&defaultConfig, p.OpenAIConfig, mergo.WithOverride)
+	err := mergo.Merge(p, defaultConfig)
 	if err != nil {
 		return fmt.Errorf("failed to merge OpenAI config: %w", err)
 	}
-
-	p.OpenAIConfig = defaultConfig
 
 	return nil
 }
@@ -77,47 +85,46 @@ func (p *EmbeddingModelProviderOpenAI) fillDefaults() error {
 func (p *EmbeddingModelProviderOpenAI) EmbeddingFunc() (cg.EmbeddingFunc, error) {
 	var embeddingFunc cg.EmbeddingFunc
 
-	switch strings.ToLower(p.OpenAIConfig.APIType) {
-
+	switch strings.ToLower(p.APIType) {
 	// except for Azure, most other OpenAI API compatible providers only differ in the normalization of output vectors (apart from the obvious API endpoint, etc.)
 	case "azure", "azure_ad":
 		// TODO: clean this up to support inputting the full deployment URL
-		deployment := p.OpenAIConfig.AzureOpenAIConfig.Deployment
+		deployment := p.AzureOpenAIConfig.Deployment
 		if deployment == "" {
-			deployment = p.OpenAIConfig.EmbeddingModel
+			deployment = p.EmbeddingModel
 		}
 
-		deploymentURL, err := url.Parse(p.OpenAIConfig.BaseURL)
+		deploymentURL, err := url.Parse(p.BaseURL)
 		if err != nil || deploymentURL == nil {
-			return nil, fmt.Errorf("failed to parse OpenAI Base URL %q: %w", p.OpenAIConfig.BaseURL, err)
+			return nil, fmt.Errorf("failed to parse OpenAI Base URL %q: %w", p.BaseURL, err)
 		}
 
 		deploymentURL = deploymentURL.JoinPath("openai", "deployments", deployment)
 
-		slog.Debug("Using Azure OpenAI API", "deploymentURL", deploymentURL.String(), "APIVersion", p.OpenAIConfig.APIVersion)
+		slog.Debug("Using Azure OpenAI API", "deploymentURL", deploymentURL.String(), "APIVersion", p.APIVersion)
 
 		embeddingFunc = cg.NewEmbeddingFuncAzureOpenAI(
-			p.OpenAIConfig.APIKey,
+			p.APIKey,
 			deploymentURL.String(),
-			p.OpenAIConfig.APIVersion,
+			p.APIVersion,
 			"",
 		)
 	case "open_ai":
 		cfg := cg.NewOpenAICompatConfig(
-			p.OpenAIConfig.BaseURL,
-			p.OpenAIConfig.APIKey,
-			p.OpenAIConfig.EmbeddingModel,
+			p.BaseURL,
+			p.APIKey,
+			p.EmbeddingModel,
 		).
 			WithNormalized(true).
-			WithEmbeddingsEndpoint(p.OpenAIConfig.EmbeddingEndpoint)
+			WithEmbeddingsEndpoint(p.EmbeddingEndpoint)
 		embeddingFunc = cg.NewEmbeddingFuncOpenAICompat(cfg)
 	default:
-		return nil, fmt.Errorf("unknown OpenAI API type: %q", p.OpenAIConfig.APIType)
+		return nil, fmt.Errorf("unknown OpenAI API type: %q", p.APIType)
 	}
 
 	return embeddingFunc, nil
 }
 
 func (p *EmbeddingModelProviderOpenAI) Config() any {
-	return p.OpenAIConfig
+	return p
 }

--- a/pkg/datastore/embeddings/test_assets/testcfg.yaml
+++ b/pkg/datastore/embeddings/test_assets/testcfg.yaml
@@ -1,4 +1,8 @@
 embeddings:
-  openai:
-    apiKey: "sk-1234567890abcdef"
-    embeddingEndpoint: "/foobar"
+  provider: "openai"
+  providers:
+    - name: openai
+      type: openai
+      config:
+        apiKey: "sk-1234567890abcdef"
+        embeddingEndpoint: "/foobar"

--- a/pkg/datastore/embeddings/types/provider.go
+++ b/pkg/datastore/embeddings/types/provider.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"github.com/go-viper/mapstructure/v2"
-	"github.com/gptscript-ai/knowledge/pkg/config"
 	cg "github.com/philippgille/chromem-go"
 )
 
@@ -11,27 +9,4 @@ type EmbeddingModelProvider interface {
 	EmbeddingFunc() (cg.EmbeddingFunc, error)
 	Configure() error
 	Config() any
-}
-
-func AsEmbeddingModelProviderConfig(emp EmbeddingModelProvider) (config.EmbeddingsProviderConfig, error) {
-
-	var cfg map[string]any
-
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "koanf",
-		Result:  &cfg,
-	})
-
-	if err != nil {
-		return config.EmbeddingsProviderConfig{}, err
-	}
-
-	if err := decoder.Decode(emp.Config()); err != nil {
-		return config.EmbeddingsProviderConfig{}, err
-	}
-
-	return config.EmbeddingsProviderConfig{
-		Type:   emp.Name(),
-		Config: cfg,
-	}, nil
 }

--- a/pkg/datastore/embeddings/types/provider.go
+++ b/pkg/datastore/embeddings/types/provider.go
@@ -5,5 +5,6 @@ import cg "github.com/philippgille/chromem-go"
 type EmbeddingModelProvider interface {
 	Name() string
 	EmbeddingFunc() (cg.EmbeddingFunc, error)
+	Configure() error
 	Config() any
 }

--- a/pkg/datastore/embeddings/types/provider.go
+++ b/pkg/datastore/embeddings/types/provider.go
@@ -1,10 +1,37 @@
 package types
 
-import cg "github.com/philippgille/chromem-go"
+import (
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/gptscript-ai/knowledge/pkg/config"
+	cg "github.com/philippgille/chromem-go"
+)
 
 type EmbeddingModelProvider interface {
 	Name() string
 	EmbeddingFunc() (cg.EmbeddingFunc, error)
 	Configure() error
 	Config() any
+}
+
+func AsEmbeddingModelProviderConfig(emp EmbeddingModelProvider) (config.EmbeddingsProviderConfig, error) {
+
+	var cfg map[string]any
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "koanf",
+		Result:  &cfg,
+	})
+
+	if err != nil {
+		return config.EmbeddingsProviderConfig{}, err
+	}
+
+	if err := decoder.Decode(emp.Config()); err != nil {
+		return config.EmbeddingsProviderConfig{}, err
+	}
+
+	return config.EmbeddingsProviderConfig{
+		Type:   emp.Name(),
+		Config: cfg,
+	}, nil
 }

--- a/pkg/datastore/embeddings/vertex/vertex.go
+++ b/pkg/datastore/embeddings/vertex/vertex.go
@@ -9,10 +9,10 @@ import (
 )
 
 type EmbeddingProviderVertex struct {
-	APIKey      string `koanf:"apiKey" env:"VERTEX_API_KEY"`
-	APIEndpoint string `koanf:"apiEndpoint" env:"VERTEX_API_ENDPOINT"`
-	Project     string `koanf:"project" env:"VERTEX_PROJECT"`
-	Model       string `koanf:"model" env:"VERTEX_MODEL"`
+	APIKey      string `koanf:"apiKey" env:"VERTEX_API_KEY" export:"false"`
+	APIEndpoint string `koanf:"apiEndpoint" env:"VERTEX_API_ENDPOINT" export:"true"`
+	Project     string `koanf:"project" env:"VERTEX_PROJECT" export:"true"`
+	Model       string `koanf:"model" env:"VERTEX_MODEL" export:"required"`
 }
 
 const EmbeddingProviderVertexName = "vertex"
@@ -21,17 +21,16 @@ func (p *EmbeddingProviderVertex) Name() string {
 	return EmbeddingProviderVertexName
 }
 
-func New(c EmbeddingProviderVertex) (*EmbeddingProviderVertex, error) {
-
-	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderVertexName), &c); err != nil {
-		return nil, fmt.Errorf("failed to fill Vertex config from environment: %w", err)
+func (p *EmbeddingProviderVertex) Configure() error {
+	if err := load.FillConfigEnv(strings.ToUpper(EmbeddingProviderVertexName), &p); err != nil {
+		return fmt.Errorf("failed to fill Vertex config from environment: %w", err)
 	}
 
-	if err := c.fillDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to fill Vertex defaults: %w", err)
+	if err := p.fillDefaults(); err != nil {
+		return fmt.Errorf("failed to fill Vertex defaults: %w", err)
 	}
 
-	return &c, nil
+	return nil
 }
 
 func (p *EmbeddingProviderVertex) fillDefaults() error {

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
-	etypes "github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/types"
 	"log/slog"
 
 	"github.com/acorn-io/z"
@@ -53,7 +52,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 	// Check if Dataset has an embedding config attached
 	if ds.EmbeddingsProviderConfig == nil {
 		slog.Info("Embeddingsconfig", "config", s.EmbeddingConfig)
-		ncfg, err := etypes.AsEmbeddingModelProviderConfig(s.EmbeddingModelProvider)
+		ncfg, err := embeddings.AsEmbeddingModelProviderConfig(s.EmbeddingModelProvider, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get embedding model provider config: %w", err)
 		}
@@ -77,6 +76,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 		}
 		err = embeddings.CompareRequiredFields(s.EmbeddingModelProvider.Config(), dsEmbeddingProvider.Config())
 		if err != nil {
+			slog.Info("Dataset has attached embeddings provider config", "config", ds.EmbeddingsProviderConfig)
 			return nil, fmt.Errorf("mismatching embedding provider configs: %w", err)
 		}
 	}

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -74,6 +74,8 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 		if err != nil {
 			return nil, fmt.Errorf("failed to get embeddings model provider: %w", err)
 		}
+
+		// TODO: Use the dataset-provided config (merge with override)
 		err = embeddings.CompareRequiredFields(s.EmbeddingModelProvider.Config(), dsEmbeddingProvider.Config())
 		if err != nil {
 			slog.Info("Dataset has attached embeddings provider config", "config", ds.EmbeddingsProviderConfig)

--- a/pkg/index/models.go
+++ b/pkg/index/models.go
@@ -8,10 +8,10 @@ import (
 // Dataset refers to a VectorDB data space.
 // @Description Dataset refers to a VectorDB data space.
 type Dataset struct {
-	ID               string                   `gorm:"primaryKey" json:"id"`
-	EmbeddingsConfig *config.EmbeddingsConfig `json:"embeddingsConfig,omitempty" gorm:"serializer:json"`
-	Files            []File                   `gorm:"foreignKey:Dataset;references:ID;constraint:OnDelete:CASCADE;"`
-	Metadata         map[string]any           `json:"metadata,omitempty" gorm:"serializer:json"`
+	ID                       string                           `gorm:"primaryKey" json:"id"`
+	EmbeddingsProviderConfig *config.EmbeddingsProviderConfig `json:"embeddingsProviderConfig,omitempty" gorm:"serializer:json"`
+	Files                    []File                           `gorm:"foreignKey:Dataset;references:ID;constraint:OnDelete:CASCADE;"`
+	Metadata                 map[string]any                   `json:"metadata,omitempty" gorm:"serializer:json"`
 }
 
 type File struct {

--- a/pkg/index/models.go
+++ b/pkg/index/models.go
@@ -1,15 +1,17 @@
 package index
 
 import (
+	"github.com/gptscript-ai/knowledge/pkg/config"
 	"time"
 )
 
 // Dataset refers to a VectorDB data space.
 // @Description Dataset refers to a VectorDB data space.
 type Dataset struct {
-	ID       string         `gorm:"primaryKey" json:"id"`
-	Files    []File         `gorm:"foreignKey:Dataset;references:ID;constraint:OnDelete:CASCADE;"`
-	Metadata map[string]any `json:"metadata,omitempty" gorm:"serializer:json"`
+	ID               string                   `gorm:"primaryKey" json:"id"`
+	EmbeddingsConfig *config.EmbeddingsConfig `json:"embeddingsConfig,omitempty" gorm:"serializer:json"`
+	Files            []File                   `gorm:"foreignKey:Dataset;references:ID;constraint:OnDelete:CASCADE;"`
+	Metadata         map[string]any           `json:"metadata,omitempty" gorm:"serializer:json"`
 }
 
 type File struct {


### PR DESCRIPTION
- embedding providers can now be freely named in the config file as it's turned into a plain list
	-	this also allows for an "infinite" number of providers that can be configured and even several of the same type
- the provider choice is now only configurable via flag or env var, **not** via config file
- datasets are now automatically created upon ingestion, if they didn't exist before 	