### PR TITLE
feat: upsert duplicates + prune removed files

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,7 @@ type IngestPathsOpts struct {
 	IncludeHidden       bool
 	NoCreateDataset     bool
 	IsDuplicateFuncName string
+	Prune               bool // Prune deleted files
 }
 
 type Client interface {
@@ -30,6 +31,7 @@ type Client interface {
 	Ingest(ctx context.Context, datasetID string, data []byte, opts datastore.IngestOpts) ([]string, error)
 	IngestPaths(ctx context.Context, datasetID string, opts *IngestPathsOpts, paths ...string) (int, error) // returns number of files ingested
 	AskDirectory(ctx context.Context, path string, query string, opts *IngestPathsOpts, ropts *datastore.RetrieveOpts) (*dstypes.RetrievalResponse, error)
+	PrunePath(ctx context.Context, datasetID string, path string, keep []string) ([]index.File, error)
 	DeleteDocuments(ctx context.Context, datasetID string, documentIDs ...string) error
 	Retrieve(ctx context.Context, datasetID string, query string, opts datastore.RetrieveOpts) (*dstypes.RetrievalResponse, error)
 	ExportDatasets(ctx context.Context, path string, datasets ...string) error

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,14 +11,15 @@ import (
 )
 
 type IngestPathsOpts struct {
-	IgnoreExtensions []string
-	Concurrency      int
-	Recursive        bool
-	TextSplitterOpts *textsplitter.TextSplitterOpts
-	IngestionFlows   []flows.IngestionFlow
-	IgnoreFile       string
-	IncludeHidden    bool
-	NoCreateDataset  bool
+	IgnoreExtensions    []string
+	Concurrency         int
+	Recursive           bool
+	TextSplitterOpts    *textsplitter.TextSplitterOpts
+	IngestionFlows      []flows.IngestionFlow
+	IgnoreFile          string
+	IncludeHidden       bool
+	NoCreateDataset     bool
+	IsDuplicateFuncName string
 }
 
 type Client interface {

--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -58,7 +58,6 @@ func readIgnoreFile(path string) ([]gitignore.Pattern, error) {
 }
 
 func ingestPaths(ctx context.Context, opts *IngestPathsOpts, ingestionFunc func(path string) error, paths ...string) (int, error) {
-
 	ingestedFilesCount := 0
 
 	var ignorePatterns []gitignore.Pattern

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -155,7 +155,12 @@ func (c *DefaultClient) IngestPaths(ctx context.Context, datasetID string, opts 
 		return err
 	}
 
-	return ingestPaths(ctx, opts, ingestFile, paths...)
+	return ingestPaths(ctx, c, opts, datasetID, ingestFile, paths...)
+}
+
+func (c *DefaultClient) PrunePath(ctx context.Context, datasetID string, path string, keep []string) ([]index.File, error) {
+	// TODO: implement
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (c *DefaultClient) DeleteDocuments(_ context.Context, datasetID string, documentIDs ...string) error {

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -116,7 +116,6 @@ func (c *DefaultClient) Ingest(_ context.Context, datasetID string, data []byte,
 }
 
 func (c *DefaultClient) IngestPaths(ctx context.Context, datasetID string, opts *IngestPathsOpts, paths ...string) (int, error) {
-
 	_, err := getOrCreateDataset(ctx, c, datasetID, !opts.NoCreateDataset)
 	if err != nil {
 		return 0, err

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -103,7 +103,15 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 		return err
 	}
 
-	return ingestPaths(ctx, opts, ingestFile, paths...)
+	return ingestPaths(ctx, c, opts, datasetID, ingestFile, paths...)
+}
+
+func (c *StandaloneClient) PrunePath(ctx context.Context, datasetID string, path string, keep []string) ([]index.File, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path for %s: %w", path, err)
+	}
+	return c.Datastore.PruneFiles(ctx, datasetID, abs, keep)
 }
 
 func (c *StandaloneClient) DeleteDocuments(ctx context.Context, datasetID string, documentIDs ...string) error {

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -57,7 +57,6 @@ func (c *StandaloneClient) ListDatasets(ctx context.Context) ([]types.Dataset, e
 }
 
 func (c *StandaloneClient) Ingest(ctx context.Context, datasetID string, data []byte, opts datastore.IngestOpts) ([]string, error) {
-
 	return c.Datastore.Ingest(ctx, datasetID, data, opts)
 }
 
@@ -92,7 +91,7 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 				Size:         finfo.Size(),
 				ModifiedAt:   finfo.ModTime(),
 			},
-			IsDuplicateFunc: datastore.DedupeByFileMetadata,
+			IsDuplicateFuncName: opts.IsDuplicateFuncName,
 		}
 
 		if opts != nil {

--- a/pkg/cmd/askdir.go
+++ b/pkg/cmd/askdir.go
@@ -38,11 +38,12 @@ func (s *ClientAskDir) Run(cmd *cobra.Command, args []string) error {
 	query := args[0]
 
 	ingestOpts := &client.IngestPathsOpts{
-		IgnoreExtensions: strings.Split(s.IgnoreExtensions, ","),
-		Concurrency:      s.Concurrency,
-		Recursive:        !s.NoRecursive,
-		IgnoreFile:       s.IgnoreFile,
-		IncludeHidden:    s.IncludeHidden,
+		IgnoreExtensions:    strings.Split(s.IgnoreExtensions, ","),
+		Concurrency:         s.Concurrency,
+		Recursive:           !s.NoRecursive,
+		IgnoreFile:          s.IgnoreFile,
+		IncludeHidden:       s.IncludeHidden,
+		IsDuplicateFuncName: s.DeduplicationFuncName,
 	}
 
 	retrieveOpts := &datastore.RetrieveOpts{

--- a/pkg/cmd/askdir.go
+++ b/pkg/cmd/askdir.go
@@ -16,7 +16,8 @@ import (
 
 type ClientAskDir struct {
 	Client
-	Path string `usage:"Path to the directory to query" short:"p" default:"."`
+	Path    string `usage:"Path to the directory to query" short:"p" default:"."`
+	NoPrune bool   `usage:"Do not prune deleted files" env:"KNOW_ASKDIR_NO_PRUNE"`
 	ClientIngestOpts
 	ClientRetrieveOpts
 	ClientFlowsConfig
@@ -44,6 +45,7 @@ func (s *ClientAskDir) Run(cmd *cobra.Command, args []string) error {
 		IgnoreFile:          s.IgnoreFile,
 		IncludeHidden:       s.IncludeHidden,
 		IsDuplicateFuncName: s.DeduplicationFuncName,
+		Prune:               !s.NoPrune,
 	}
 
 	retrieveOpts := &datastore.RetrieveOpts{

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -105,7 +105,6 @@ func (s *Client) getClient() (client.Client, error) {
 	}
 
 	if s.Server == "" || s.Server == "standalone" {
-
 		provider, err := embeddings.GetSelectedEmbeddingsModelProvider(s.EmbeddingModelProvider, cfg.EmbeddingsConfig)
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -15,6 +15,7 @@ import (
 type ClientIngest struct {
 	Client
 	Dataset string `usage:"Target Dataset ID" short:"d" default:"default" env:"KNOW_TARGET_DATASET"`
+	Prune   bool   `usage:"Prune deleted files" env:"KNOW_INGEST_PRUNE"`
 	ClientIngestOpts
 	textsplitter.TextSplitterOpts
 	ClientFlowsConfig
@@ -62,6 +63,7 @@ func (s *ClientIngest) Run(cmd *cobra.Command, args []string) error {
 		IgnoreFile:          s.IgnoreFile,
 		IncludeHidden:       s.IncludeHidden,
 		IsDuplicateFuncName: s.DeduplicationFuncName,
+		Prune:               s.Prune,
 	}
 
 	if s.FlowsFile != "" {

--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -21,12 +21,13 @@ type ClientIngest struct {
 }
 
 type ClientIngestOpts struct {
-	IgnoreExtensions string `usage:"Comma-separated list of file extensions to ignore" env:"KNOW_INGEST_IGNORE_EXTENSIONS"`
-	IgnoreFile       string `usage:"Path to a .gitignore style file" env:"KNOW_INGEST_IGNORE_FILE"`
-	IncludeHidden    bool   `usage:"Include hidden files and directories" default:"false" env:"KNOW_INGEST_INCLUDE_HIDDEN"`
-	Concurrency      int    `usage:"Number of concurrent ingestion processes" default:"10" env:"KNOW_INGEST_CONCURRENCY"`
-	NoRecursive      bool   `usage:"Don't recursively ingest directories" default:"false" env:"KNOW_NO_INGEST_RECURSIVE"`
-	NoCreateDataset  bool   `usage:"Do NOT create the dataset if it doesn't exist" default:"true" env:"KNOW_INGEST_NO_CREATE_DATASET"`
+	IgnoreExtensions      string `usage:"Comma-separated list of file extensions to ignore" env:"KNOW_INGEST_IGNORE_EXTENSIONS"`
+	IgnoreFile            string `usage:"Path to a .gitignore style file" env:"KNOW_INGEST_IGNORE_FILE"`
+	IncludeHidden         bool   `usage:"Include hidden files and directories" default:"false" env:"KNOW_INGEST_INCLUDE_HIDDEN"`
+	Concurrency           int    `usage:"Number of concurrent ingestion processes" default:"10" env:"KNOW_INGEST_CONCURRENCY"`
+	NoRecursive           bool   `usage:"Don't recursively ingest directories" default:"false" env:"KNOW_NO_INGEST_RECURSIVE"`
+	NoCreateDataset       bool   `usage:"Do NOT create the dataset if it doesn't exist" default:"true" env:"KNOW_INGEST_NO_CREATE_DATASET"`
+	DeduplicationFuncName string `usage:"Name of the deduplication function to use" name:"dedupe-func" env:"KNOW_INGEST_DEDUPE_FUNC"`
 }
 
 func (s *ClientIngest) Customize(cmd *cobra.Command) {
@@ -54,12 +55,13 @@ func (s *ClientIngest) Run(cmd *cobra.Command, args []string) error {
 	filePath := args[0]
 
 	ingestOpts := &client.IngestPathsOpts{
-		IgnoreExtensions: strings.Split(s.IgnoreExtensions, ","),
-		Concurrency:      s.Concurrency,
-		Recursive:        !s.NoRecursive,
-		TextSplitterOpts: &s.TextSplitterOpts,
-		IgnoreFile:       s.IgnoreFile,
-		IncludeHidden:    s.IncludeHidden,
+		IgnoreExtensions:    strings.Split(s.IgnoreExtensions, ","),
+		Concurrency:         s.Concurrency,
+		Recursive:           !s.NoRecursive,
+		TextSplitterOpts:    &s.TextSplitterOpts,
+		IgnoreFile:          s.IgnoreFile,
+		IncludeHidden:       s.IncludeHidden,
+		IsDuplicateFuncName: s.DeduplicationFuncName,
 	}
 
 	if s.FlowsFile != "" {

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -35,7 +35,6 @@ func (s *Server) Customize(cmd *cobra.Command) {
 }
 
 func (s *Server) Run(cmd *cobra.Command, _ []string) error {
-
 	slog.Warn("The knowledge server is underdeveloped and lacking behind the standalone client right now, use at your own risk!") // FIXME: Bring the server on par with the standalone client and drop this warning
 
 	cfg, err := config.LoadConfig(s.ConfigFile)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,5 +47,4 @@ func TestEmbeddingsConfig_ClearUnselected(t *testing.T) {
 
 	require.Len(t, ec.Providers, 1)
 	require.Equal(t, "cohere", ec.Providers[0].Name)
-
 }

--- a/pkg/datastore/dataset.go
+++ b/pkg/datastore/dataset.go
@@ -15,7 +15,6 @@ type UpdateDatasetOpts struct {
 }
 
 func (s *Datastore) NewDataset(ctx context.Context, dataset index.Dataset) error {
-
 	// Create dataset
 	tx := s.Index.WithContext(ctx).Create(&dataset)
 	if tx.Error != nil {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -68,7 +68,6 @@ func GetDatastorePaths(dsn, vectordbPath string) (string, string, bool, error) {
 }
 
 func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingProvider etypes.EmbeddingModelProvider) (*Datastore, error) {
-
 	dsn, vectorDBPath, isArchive, err := GetDatastorePaths(dsn, vectorDBPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine datastore paths: %w", err)

--- a/pkg/datastore/deduplication.go
+++ b/pkg/datastore/deduplication.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/gptscript-ai/knowledge/pkg/index"
 )
@@ -16,6 +17,7 @@ var IsDuplicateFuncs = map[string]IsDuplicateFunc{
 	"dummy":         DummyDedupe,
 	"none":          DummyDedupe,
 	"ignore":        DummyDedupe,
+	"upsert":        DedupeUpsert,
 }
 
 // DedupeByFileMetadata is a deduplication function that checks if the document is a duplicate based on the file metadata.
@@ -32,6 +34,36 @@ func DedupeByFileMetadata(ctx context.Context, d *Datastore, datasetID string, c
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func DedupeUpsert(ctx context.Context, d *Datastore, datasetID string, content []byte, opts IngestOpts) (bool, error) {
+	var res index.File
+	err := d.Index.WithContext(ctx).Model(&index.File{}).
+		Where("dataset = ?", datasetID).
+		Where("absolute_path = ?", opts.FileMetadata.AbsolutePath).
+		First(&res).Error
+
+	if err != nil {
+		return false, err
+	}
+
+	if res.ID == "" {
+		return false, nil
+	}
+
+	// If incoming file is newer than the existing file, delete the existing file
+	if res.ModifiedAt.Before(opts.FileMetadata.ModifiedAt) {
+		slog.Debug("Upserting by deleting existing file", "file", res.ID, "absPath", res.AbsolutePath, "modified_at", res.ModifiedAt, "new_modified_at", opts.FileMetadata.ModifiedAt)
+		err = d.DeleteFile(ctx, datasetID, res.ID)
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	slog.Debug("Not upserting: incoming file is not newer", "file", res.ID, "absPath", res.AbsolutePath, "modified_at", res.ModifiedAt, "new_modified_at", opts.FileMetadata.ModifiedAt)
+
+	return true, nil
 }
 
 // DummyDedupe is a dummy deduplication function that always returns false (i.e. "No Duplicate").

--- a/pkg/datastore/deduplication.go
+++ b/pkg/datastore/deduplication.go
@@ -2,6 +2,8 @@ package datastore
 
 import (
 	"context"
+	"errors"
+	"gorm.io/gorm"
 	"log/slog"
 
 	"github.com/gptscript-ai/knowledge/pkg/index"
@@ -43,7 +45,7 @@ func DedupeUpsert(ctx context.Context, d *Datastore, datasetID string, content [
 		Where("absolute_path = ?", opts.FileMetadata.AbsolutePath).
 		First(&res).Error
 
-	if err != nil {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return false, err
 	}
 

--- a/pkg/datastore/documentloader/remote/github.go
+++ b/pkg/datastore/documentloader/remote/github.go
@@ -12,7 +12,6 @@ import (
 // CloneRepo clones a git repository to a target directory
 // repo is the repository to clone - may contain an @ symbol to specify a commit, tag or branch (prioritized in that order)
 func CloneRepo(repo, target string) error {
-
 	atSplit := strings.Split(repo, "@")
 
 	if len(atSplit) > 2 {

--- a/pkg/datastore/embeddings/embeddings.go
+++ b/pkg/datastore/embeddings/embeddings.go
@@ -34,7 +34,6 @@ func GetSelectedEmbeddingsModelProvider(selected string, embeddingsConfig config
 	}
 
 	return provider, nil
-
 }
 
 func ProviderFromConfig(providerConfig config.EmbeddingsProviderConfig) (types.EmbeddingModelProvider, error) {
@@ -90,7 +89,6 @@ func FindProviderConfig(name string, providers []config.EmbeddingsProviderConfig
 }
 
 func GetProviderCfg(name string, embeddingsConfig config.EmbeddingsConfig) (*config.EmbeddingsProviderConfig, error) {
-
 	providerCfg := FindProviderConfig(name, embeddingsConfig.Providers)
 	if providerCfg == nil {
 		// no config with that name exists, so we assume the name is the type
@@ -212,7 +210,6 @@ func CompareRequiredFields(a, b any) error {
 }
 
 func AsEmbeddingModelProviderConfig(emp types.EmbeddingModelProvider, export bool) (config.EmbeddingsProviderConfig, error) {
-
 	var cfg map[string]any
 
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -27,7 +27,6 @@ type IngestOpts struct {
 
 // Ingest loads a document from a reader and adds it to the dataset.
 func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte, opts IngestOpts) ([]string, error) {
-
 	// Get dataset
 	ds, err := s.GetDataset(ctx, datasetID)
 	if err != nil {
@@ -37,7 +36,6 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 	// Dataset does not exist - create it if requested, else error out
 	if ds == nil {
 		return nil, fmt.Errorf("dataset %q not found", datasetID)
-
 	}
 
 	// Check if Dataset has an embedding config attached
@@ -75,7 +73,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 	}
 
 	// File Deduplication
-	isDuplicate := DummyDedupe // default: no deduplication
+	isDuplicate := DedupeUpsert // default: no deduplication
 	if opts.IsDuplicateFuncName != "" {
 		df, ok := IsDuplicateFuncs[opts.IsDuplicateFuncName]
 		if !ok {


### PR DESCRIPTION
New flags:

- `ingest --prune` - enable pruning of deleted files when ingesting directories
- `ingest --dedupe-func=<name>` - to set a deduplication func by name
- `askdir --no-prune` - disable pruning upon directory ingestion
- `askdir --dedupe-func=<name>` - to set a defuplication func by name

New behavior:

- files are automatically upserted upon ingestion unless a different deduplication func is specified (upsert = delete existing, if older than incoming file, then ingest incoming file, effectively replacing the old one)
- `askdir` by default prunes deleted files, while this can be enabled specifically for `ingest`

Fixes #33
Fixed #34 