### PR TITLE
add: add back old GoPDF parser and "hide" MuPDF behind mupdf build tag to allow for No-CGO builds for some OS/Arch combos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.4
 
 replace (
 	github.com/hupe1980/golc => github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7 // nbformat extension
+	github.com/ledongthuc/pdf => github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3 // fix for reading some PDFs: https://github.com/ledongthuc/pdf/pull/36 + https://github.com/iwilltry42/pdf/pull/2
 	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20240724101255-75d217fcc704 // Vertex Provider
 	github.com/tmc/langchaingo => github.com/StrongMonkey/langchaingo v0.0.0-20240617180437-9af4bee04c8b // Context-Aware Markdown Splitting
 )
@@ -32,6 +33,7 @@ require (
 	github.com/knadh/koanf/providers/env v0.1.0
 	github.com/knadh/koanf/providers/rawbytes v0.1.0
 	github.com/knadh/koanf/v2 v2.1.1
+	github.com/ledongthuc/pdf v0.0.0-20240201131950-da5b75280b06
 	github.com/lu4p/cat v0.1.5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/philippgille/chromem-go v0.6.1-0.20240703185604-935ec301a0a4
@@ -115,7 +117,6 @@ require (
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
-	github.com/ledongthuc/pdf v0.0.0-20240201131950-da5b75280b06 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/iwilltry42/chromem-go v0.0.0-20240724101255-75d217fcc704 h1:nT7ROfSVU
 github.com/iwilltry42/chromem-go v0.0.0-20240724101255-75d217fcc704/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7 h1:2AzzbKVW1iP2F+ovqJKq801l6tgxYPt9m2zFKbs+i/Y=
 github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7/go.mod h1:w692KzkSTSvXROfyu+jYauNXB4YaL1s8zHPDMnNW88o=
+github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3 h1:rCVwFT7Q+HxpijWfSzKTYX4pCDMS7oy/I/WzU30VXyI=
+github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3/go.mod h1:p6S8B6MtbSh4sEUXw5DpOsyJVTP3N48e8Ea3mpdhZj4=
 github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7 h1:g0fAGBisHaEQ0TRq1iBvemFRf+8AEWEmBESSiWB3Vsc=
 github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
@@ -249,8 +251,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/ledongthuc/pdf v0.0.0-20240201131950-da5b75280b06 h1:kacRlPN7EN++tVpGUorNGPn/4DnB7/DfTY82AOn6ccU=
-github.com/ledongthuc/pdf v0.0.0-20240201131950-da5b75280b06/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=

--- a/pkg/datastore/documentloader/defaults.go
+++ b/pkg/datastore/documentloader/defaults.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"code.sajari.com/docconv/v2"
+	pdfdefaults "github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/pdf/defaults"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/filetypes"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	golcdocloaders "github.com/hupe1980/golc/documentloader"
@@ -24,12 +25,7 @@ func DefaultDocLoaderFunc(filetype string) func(ctx context.Context, reader io.R
 	switch filetype {
 	case ".pdf", "application/pdf":
 		return func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {
-			r, nerr := NewPDF(reader)
-			if nerr != nil {
-				slog.Error("Failed to create PDF loader", "error", nerr)
-				return nil, nerr
-			}
-			return r.Load(ctx)
+			return pdfdefaults.DefaultPDFReaderFunc(ctx, reader)
 		}
 	case ".html", "text/html":
 		return func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {

--- a/pkg/datastore/documentloader/documentloaders_test.go
+++ b/pkg/datastore/documentloader/documentloaders_test.go
@@ -2,6 +2,7 @@ package documentloader
 
 import (
 	"context"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/pdf/gopdf"
 	"strings"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 func TestGetDocumentLoaderConfig_ValidLoader(t *testing.T) {
 	cfg, err := GetDocumentLoaderConfig("pdf")
 	assert.NoError(t, err)
-	assert.IsTypef(t, PDFOptions{}, cfg, "cfg is not of type PDFOptions")
+	assert.IsTypef(t, gopdf.PDFOptions{}, cfg, "cfg is not of type PDFOptions")
 }
 
 func TestGetDocumentLoaderConfig_InvalidLoader(t *testing.T) {
@@ -30,7 +31,7 @@ func TestGetDocumentLoaderFunc_ValidLoaderWithInvalidConfig(t *testing.T) {
 }
 
 func TestGetDocumentLoaderFunc_ValidLoaderWithValidConfig(t *testing.T) {
-	_, err := GetDocumentLoaderFunc("pdf", PDFOptions{})
+	_, err := GetDocumentLoaderFunc("pdf", gopdf.PDFOptions{})
 	assert.NoError(t, err)
 }
 
@@ -48,7 +49,7 @@ func TestGetDocumentLoaderFunc_LoadPlainText(t *testing.T) {
 }
 
 func TestGetDocumentLoaderFunc_LoadPDF(t *testing.T) {
-	loaderFunc, _ := GetDocumentLoaderFunc("pdf", PDFOptions{})
+	loaderFunc, _ := GetDocumentLoaderFunc("pdf", gopdf.PDFOptions{})
 	content := `
 %PDF-1.4
 1 0 obj

--- a/pkg/datastore/documentloader/mupdf.go
+++ b/pkg/datastore/documentloader/mupdf.go
@@ -1,0 +1,48 @@
+//go:build mupdf
+
+package documentloader
+
+import (
+	"context"
+	"fmt"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/pdf/defaults"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/pdf/mupdf"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"github.com/mitchellh/mapstructure"
+	"io"
+	"log/slog"
+)
+
+func init() {
+
+	defaults.DefaultPDFReaderFunc = func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {
+		slog.Debug("Default PDF Reader is MuPDF")
+		r, err := mupdf.NewPDF(reader)
+		if err != nil {
+			slog.Error("Failed to create MuPDF loader", "error", err)
+			return nil, err
+		}
+		return r.Load(ctx)
+	}
+
+	MuPDFGetter = func(config any) (LoaderFunc, error) {
+		var pdfConfig mupdf.PDFOptions
+		if config != nil {
+			slog.Debug("PDF custom config", "config", config)
+			if err := mapstructure.Decode(config, &pdfConfig); err != nil {
+				return nil, fmt.Errorf("failed to decode PDF document loader configuration: %w", err)
+			}
+			slog.Debug("PDF custom config (decoded)", "pdfConfig", pdfConfig)
+		}
+		return func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {
+			r, err := mupdf.NewPDF(reader, mupdf.WithConfig(pdfConfig))
+			if err != nil {
+				slog.Error("Failed to create PDF loader", "error", err)
+				return nil, err
+			}
+			return r.Load(ctx)
+		}, nil
+	}
+
+	MuPDFConfig = mupdf.PDFOptions{}
+}

--- a/pkg/datastore/documentloader/pdf/defaults/defaults.go
+++ b/pkg/datastore/documentloader/pdf/defaults/defaults.go
@@ -1,0 +1,18 @@
+package defaults
+
+import (
+	"context"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/pdf/gopdf"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"io"
+	"log/slog"
+)
+
+var DefaultPDFReaderFunc func(ctx context.Context, reader io.Reader) ([]vs.Document, error) = func(ctx context.Context, reader io.Reader) ([]vs.Document, error) {
+	slog.Debug("Default PDF reader is GoPDF")
+	r, err := gopdf.NewDefaultPDF(reader)
+	if err != nil {
+		return nil, err
+	}
+	return r.Load(ctx)
+}

--- a/pkg/datastore/documentloader/pdf/gopdf/pdf.go
+++ b/pkg/datastore/documentloader/pdf/gopdf/pdf.go
@@ -1,0 +1,216 @@
+package gopdf
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"github.com/ledongthuc/pdf"
+)
+
+/*
+ * Credits to https://github.com/hupe1980/golc/blob/main/documentloader/pdf.go
+ */
+
+// Compile time check to ensure PDF satisfies the DocumentLoader interface.
+var _ types.DocumentLoader = (*PDF)(nil)
+
+type PDFOptions struct {
+	// Password for encrypted PDF files.
+	Password string
+
+	// Page number to start loading from (default is 1).
+	StartPage uint
+
+	// Maximum number of pages to load (0 for all pages).
+	MaxPages uint
+
+	// Source is the name of the pdf document
+	Source string
+
+	// InterpreterConfig is the configuration for the PDF interpreter.
+	InterpreterConfig *pdf.InterpreterConfig
+}
+
+// WithConfig sets the PDF loader configuration.
+func WithConfig(config PDFOptions) func(o *PDFOptions) {
+	return func(o *PDFOptions) {
+		*o = config
+	}
+}
+
+// WithInterpreterConfig sets the interpreter config for the PDF loader.
+func WithInterpreterConfig(cfg pdf.InterpreterConfig) func(o *PDFOptions) {
+	return func(o *PDFOptions) {
+		o.InterpreterConfig = &cfg
+	}
+}
+
+// WithInterpreterOpts sets the interpreter options for the PDF loader.
+func WithInterpreterOpts(opts ...pdf.InterpreterOption) func(o *PDFOptions) {
+	return func(o *PDFOptions) {
+		if o.InterpreterConfig == nil {
+			o.InterpreterConfig = &pdf.InterpreterConfig{}
+		}
+		for _, opt := range opts {
+			opt(o.InterpreterConfig)
+		}
+	}
+}
+
+// PDF represents a PDF document loader that implements the DocumentLoader interface.
+type PDF struct {
+	f    io.ReaderAt
+	size int64
+	opts PDFOptions
+}
+
+func NewDefaultPDF(f io.Reader) (*PDF, error) {
+	return NewPDFFromReader(f, WithInterpreterOpts(pdf.WithIgnoreDefOfNonNameVals([]string{"CMapName"})))
+}
+
+func NewPDFFromReader(f io.Reader, optFns ...func(o *PDFOptions)) (*PDF, error) {
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PDF data: %w", err)
+	}
+	return NewPDF(bytes.NewReader(data), int64(len(data)), optFns...)
+}
+
+// NewPDF creates a new PDF loader with the given options.
+func NewPDF(f io.ReaderAt, size int64, optFns ...func(o *PDFOptions)) (*PDF, error) {
+	opts := PDFOptions{
+		StartPage: 1,
+	}
+
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+
+	if opts.StartPage == 0 {
+		opts.StartPage = 1
+	}
+
+	return &PDF{
+		f:    f,
+		size: size,
+		opts: opts,
+	}, nil
+}
+
+// NewPDFFromFile creates a new PDF loader with the given options.
+func NewPDFFromFile(f *os.File, optFns ...func(o *PDFOptions)) (*PDF, error) {
+	opts := PDFOptions{
+		StartPage: 1,
+		Source:    f.Name(),
+	}
+
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+
+	if opts.StartPage == 0 {
+		opts.StartPage = 1
+	}
+
+	finfo, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewPDF(f, finfo.Size(), func(o *PDFOptions) {
+		*o = opts
+	})
+}
+
+// Load loads the PDF document and returns a slice of vs.Document containing the page contents and metadata.
+func (l *PDF) Load(ctx context.Context) ([]vs.Document, error) {
+	var (
+		reader *pdf.Reader
+		err    error
+	)
+
+	if l.opts.Password != "" {
+		reader, err = pdf.NewReaderEncrypted(l.f, l.size, func() string {
+			return l.opts.Password
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		reader, err = pdf.NewReader(l.f, l.size)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	numPages := reader.NumPage()
+	if l.opts.StartPage > uint(numPages) {
+		return nil, fmt.Errorf("startpage out of page range: 1-%d", numPages)
+	}
+
+	maxPages := numPages - int(l.opts.StartPage) + 1
+	if l.opts.MaxPages > 0 && numPages > int(l.opts.MaxPages) {
+		maxPages = int(l.opts.MaxPages)
+	}
+
+	docs := make([]vs.Document, 0, numPages)
+
+	fonts := make(map[string]*pdf.Font)
+
+	page := 1
+
+	for i := int(l.opts.StartPage); i < maxPages+int(l.opts.StartPage); i++ {
+		p := reader.Page(i)
+
+		for _, name := range p.Fonts() {
+			if _, ok := fonts[name]; !ok {
+				f := p.Font(name)
+				fonts[name] = &f
+			}
+		}
+
+		if l.opts.InterpreterConfig == nil {
+			l.opts.InterpreterConfig = &pdf.InterpreterConfig{}
+		}
+
+		text, err := p.GetPlainText(fonts, pdf.WithInterpreterConfig(*l.opts.InterpreterConfig))
+		if err != nil {
+			return nil, err
+		}
+
+		// add the document to the doc list
+		doc := vs.Document{
+			Content: strings.TrimSpace(text),
+			Metadata: map[string]any{
+				"page":       page,
+				"totalPages": maxPages,
+			},
+		}
+
+		if l.opts.Source != "" {
+			doc.Metadata["source"] = l.opts.Source
+		}
+
+		docs = append(docs, doc)
+
+		page++
+	}
+
+	return docs, nil
+}
+
+// LoadAndSplit loads PDF documents from the provided reader and splits them using the specified text splitter.
+func (l *PDF) LoadAndSplit(ctx context.Context, splitter types.TextSplitter) ([]vs.Document, error) {
+	docs, err := l.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return splitter.SplitDocuments(docs)
+}

--- a/pkg/datastore/documentloader/pdf/mupdf/pdf.go
+++ b/pkg/datastore/documentloader/pdf/mupdf/pdf.go
@@ -1,4 +1,6 @@
-package documentloader
+//go:build mupdf
+
+package mupdf
 
 import (
 	"context"

--- a/scripts/cross-build.sh
+++ b/scripts/cross-build.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -ex
 
-GO_TAGS="netgo"
+GO_TAGS="netgo,mupdf"
 LD_FLAGS="-s -w -X github.com/gptscript-ai/knowledge/version.Version=${GIT_TAG}"
 
-export CGO_ENABLED=1
+#
+# Main build - includes MuPDF, which requires CGO and is currently not possible to be built for linux/arm64 and windows/arm64
+#
 
+export CGO_ENABLED=1
 if [ "$(go env GOOS)" = "linux" ]; then
   # Linux: amd64, arm64
   GOARCH=amd64 go build -o dist/knowledge-linux-amd64 -tags "${GO_TAGS}" -ldflags "${LD_FLAGS}\" -extldflags \"-static\" " .
@@ -17,4 +20,17 @@ else
   # Darwin: amd64, arm64
   GOARCH=amd64 go build -o dist/knowledge-darwin-amd64 -tags "${GO_TAGS}" -ldflags "${LD_FLAGS}" .
   GOARCH=arm64 go build -o dist/knowledge-darwin-arm64 -tags "${GO_TAGS}" -ldflags "${LD_FLAGS}" .
+fi
+
+#
+# NO CGO build - Does NOT include MuPDF, which requires CGO and is currently not possible to be built for linux/arm64 and windows/arm64
+#
+if [ "$(go env GOOS)" = "linux" ]; then
+  GO_TAGS="netgo"
+  export CGO_ENABLED=0
+  # Linux: arm64
+  GOARCH=arm64 go build -o dist/knowledge-linux-arm64 -tags "${GO_TAGS}" -ldflags "${LD_FLAGS}\" -extldflags \"-static\" " .
+
+  # Windows: arm64
+  GOARCH=arm64 GOOS=windows go build -o dist/knowledge-windows-arm64.exe -tags "${GO_TAGS}" -ldflags "${LD_FLAGS}" .
 fi


### PR DESCRIPTION
Introduces a go build tag `mupdf` - which requires `CGO_ENABLED=1` to include MuPDF in the build.
Currently, MuPDF is the only piece that requires CGO, so without it, we can build static binaries.
Building **without** `mupdf` is required for linux/arm64 and windows/arm64, because at the moment there are no MuPDF library (C) builds for either.

This PR brings back the pure-Go PDF parser as the default reader for non-mupdf builds.

In the config you can now choose

- `pdf` / `gopdf` -> pure-Go PDF parser
- `mupdf` -> MuPDF (will yield an error on non-mupdf builds)

 