### PR TITLE
Fix: Make top-level tool a context

### DIFF
--- a/tool.gpt
+++ b/tool.gpt
@@ -1,9 +1,21 @@
+Name: Knowledge
+Description: Create a knowledge base from files in the workspace directory and retrieve information from it.
+Type: context
+Share Tools: local-knowledge-retriever
+Share Context: github.com/gptscript-ai/context/workspace
+
+#!sys.echo
+
+You have access to an ad-hoc RAG tool named local-knowledge-retriever. It will ingest files in the workspace on-the-fly and query them. Use it to answer questions from the user. If the answers it returns seem irrelevant, you can use other tools. When you give answers, always give a proper citation to the best of your abilities. ALWAYS prefer this tool over the read tool.
+
+---
+Name: local-knowledge-retriever
 Description: Create a knowledge base from files in the workspace directory and retrieve information from it.
 Context: github.com/gptscript-ai/context/workspace
 Credential: github.com/gptscript-ai/credential as sys.openai with OPENAI_API_KEY as env and "Please provide your OpenAI API key" as message and key as field
 Args: query: The query to search for in the knowledge directory.
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool askdir --path ${GPTSCRIPT_WORKSPACE_DIR} "${QUERY}"
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool askdir --path "${GPTSCRIPT_WORKSPACE_DIR}" "${QUERY}"
 
 ---
 name: retrieval


### PR DESCRIPTION
We need to make this tool a context so that when it is added to a
script, the script knows to use it. This also allows us to add
context/workspace as a shared context tool, which is need for this tool
to function properly.
