### PR TITLE
add: flow-global options

### DIFF
--- a/examples/chatgpt-filesearch.yaml
+++ b/examples/chatgpt-filesearch.yaml
@@ -1,0 +1,15 @@
+flows:
+  chatgpt:
+    default: true
+    globals:
+      ingestion:
+        textsplitter:
+          chunkSize: 800
+          chunkOverlap: 400
+    ingestion:
+      - filetypes: ["*"]
+        textsplitter:
+          name: text
+          options:
+            chunkSize: 811
+

--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -16,18 +16,11 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 )
 
 func isIgnored(ignore gitignore.Matcher, path string) bool {
 	return ignore.Match(strings.Split(path, string(filepath.Separator)), false)
-}
-
-func checkIgnored(path string, ignoreExtensions []string) bool {
-	ext := filepath.Ext(path)
-	slog.Debug("checking path", "path", path, "ext", ext, "ignore", ignoreExtensions)
-	return slices.Contains(ignoreExtensions, ext)
 }
 
 func readIgnoreFile(path string) ([]gitignore.Pattern, error) {

--- a/pkg/cmd/askdir.go
+++ b/pkg/cmd/askdir.go
@@ -84,7 +84,7 @@ func (s *ClientAskDir) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, ingestionFlowConfig := range flow.Ingestion {
-			ingestionFlow, err := ingestionFlowConfig.AsIngestionFlow()
+			ingestionFlow, err := ingestionFlowConfig.AsIngestionFlow(&flow.Globals.Ingestion)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -17,7 +17,7 @@ type Client struct {
 	Server           string `usage:"URL of the Knowledge API Server" default:"" env:"KNOW_SERVER_URL"`
 	datastoreArchive string
 
-	EmbeddingModelProvider string `usage:"Embedding model provider" default:"openai" env:"KNOW_EMBEDDING_MODEL_PROVIDER" name:"embedding-model-provider" default:"openai" koanf:"provider"`
+	EmbeddingModelProvider string `usage:"Embedding model provider" env:"KNOW_EMBEDDING_MODEL_PROVIDER" name:"embedding-model-provider" default:"openai" koanf:"provider"`
 	ConfigFile             string `usage:"Path to the configuration file" env:"KNOW_CONFIG_FILE" default:"" short:"c"`
 
 	config.DatabaseConfig

--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -87,7 +87,7 @@ func (s *ClientIngest) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, ingestionFlowConfig := range flow.Ingestion {
-			ingestionFlow, err := ingestionFlowConfig.AsIngestionFlow()
+			ingestionFlow, err := ingestionFlowConfig.AsIngestionFlow(&flow.Globals.Ingestion)
 			if err != nil {
 				return err
 			}

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -136,7 +136,11 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 			break
 		}
 	}
-	ingestionFlow.FillDefaults(filetype, opts.TextSplitterOpts)
+
+	if err := ingestionFlow.FillDefaults(filetype, opts.TextSplitterOpts); err != nil {
+		return nil, err
+	}
+
 	if ingestionFlow.Load == nil {
 		return nil, fmt.Errorf("unsupported filetype %q (file %q)", filetype, opts.FileMetadata.AbsolutePath)
 	}

--- a/pkg/datastore/ingest_test.go
+++ b/pkg/datastore/ingest_test.go
@@ -29,10 +29,9 @@ func TestExtractPDF(t *testing.T) {
 
 		filetype := ".pdf"
 
-		ingestionFlow := flows.NewDefaultIngestionFlow(filetype, &textSplitterOpts)
-		if ingestionFlow.Load == nil {
-			t.Fatalf("ingestionFlow.Load is nil")
-		}
+		ingestionFlow, err := flows.NewDefaultIngestionFlow(filetype, &textSplitterOpts)
+		require.NoError(t, err, "NewDefaultIngestionFlow() error = %v", err)
+		require.NotNil(t, ingestionFlow.Load, "ingestionFlow.Load is nil")
 
 		// Mandatory Transformation: Add filename to metadata
 		em := &transformers.ExtraMetadata{Metadata: map[string]any{"filename": d.Name()}}

--- a/pkg/datastore/textsplitter/textsplitter.go
+++ b/pkg/datastore/textsplitter/textsplitter.go
@@ -2,6 +2,7 @@ package textsplitter
 
 import (
 	"fmt"
+	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
 	"log/slog"
 
 	"dario.cat/mergo"
@@ -16,7 +17,7 @@ type SplitterFunc func([]vs.Document) ([]vs.Document, error)
 type TextSplitterOpts struct {
 	ChunkSize    int    `json:"chunkSize" mapstructure:"chunkSize" usage:"Textsplitter Chunk Size" default:"1024" env:"KNOW_TEXTSPLITTER_CHUNK_SIZE" name:"textsplitter-chunk-size"`
 	ChunkOverlap int    `json:"chunkOverlap" mapstructure:"chunkOverlap" usage:"Textsplitter Chunk Overlap" default:"256" env:"KNOW_TEXTSPLITTER_CHUNK_OVERLAP" name:"textsplitter-chunk-overlap"`
-	ModelName    string `json:"modelName" mapstructure:"modelName" usage:"Textsplitter Model Name" default:"gpt-4" env:"KNOW_TEXTSPLITTER_MODEL_NAME" name:"textsplitter-model-name"`
+	ModelName    string `json:"modelName" mapstructure:"modelName" usage:"Textsplitter Model Name" default:"gpt-4o" env:"KNOW_TEXTSPLITTER_MODEL_NAME" name:"textsplitter-model-name"`
 	EncodingName string `json:"encodingName" mapstructure:"encodingName" usage:"Textsplitter Encoding Name" default:"cl100k_base" env:"KNOW_TEXTSPLITTER_ENCODING_NAME" name:"textsplitter-encoding-name"`
 }
 
@@ -61,7 +62,7 @@ func GetTextSplitterConfig(name string) (any, error) {
 	}
 }
 
-func GetTextSplitterFunc(name string, config any) (SplitterFunc, error) {
+func GetTextSplitter(name string, config any) (dstypes.TextSplitter, error) {
 	switch name {
 	case "text":
 		cfg := NewTextSplitterOpts()
@@ -70,14 +71,14 @@ func GetTextSplitterFunc(name string, config any) (SplitterFunc, error) {
 			if err := mapstructure.Decode(config, &customCfg); err != nil {
 				return nil, fmt.Errorf("failed to decode text splitter configuration: %w", err)
 			}
-			slog.Debug("GetTextSplitterFunc Text (before merge)", "config", customCfg)
+			slog.Debug("GetTextSplitter Text (before merge)", "config", customCfg)
 			if err := mergo.Merge(&customCfg, cfg); err != nil {
 				return nil, fmt.Errorf("failed to merge text splitter configuration: %w", err)
 			}
 			cfg = customCfg
 		}
-		slog.Debug("TextSplitterFunc", "config", cfg)
-		return FromLangchain(NewLcgoTextSplitter(cfg)).SplitDocuments, nil
+		slog.Debug("TextSplitter", "config", cfg)
+		return FromLangchain(NewLcgoTextSplitter(cfg)), nil
 	case "markdown":
 		cfg := NewTextSplitterOpts()
 		if config != nil {
@@ -85,14 +86,14 @@ func GetTextSplitterFunc(name string, config any) (SplitterFunc, error) {
 			if err := mapstructure.Decode(config, &customCfg); err != nil {
 				return nil, fmt.Errorf("failed to decode text splitter configuration: %w", err)
 			}
-			slog.Debug("GetTextSplitterFunc Markdown (before merge)", "config", customCfg)
+			slog.Debug("GetTextSplitter Markdown (before merge)", "config", customCfg)
 			if err := mergo.Merge(&customCfg, cfg); err != nil {
 				return nil, fmt.Errorf("failed to merge text splitter configuration: %w", err)
 			}
 			cfg = customCfg
 		}
-		slog.Debug("MarkdownSplitterFunc", "config", cfg)
-		return FromLangchain(NewLcgoMarkdownSplitter(cfg)).SplitDocuments, nil
+		slog.Debug("MarkdownSplitter", "config", cfg)
+		return FromLangchain(NewLcgoMarkdownSplitter(cfg)), nil
 	default:
 		return nil, fmt.Errorf("unknown text splitter %q", name)
 	}

--- a/pkg/datastore/textsplitter/textsplitter_test.go
+++ b/pkg/datastore/textsplitter/textsplitter_test.go
@@ -17,21 +17,21 @@ func TestGetTextSplitterConfigWithInvalidName(t *testing.T) {
 }
 
 func TestGetTextSplitterFuncWithValidNameAndNilConfig(t *testing.T) {
-	_, err := GetTextSplitterFunc("text", nil)
+	_, err := GetTextSplitter("text", nil)
 	assert.NoError(t, err)
 }
 
 func TestGetTextSplitterFuncWithValidNameAndInvalidConfig(t *testing.T) {
-	_, err := GetTextSplitterFunc("text", "invalid")
+	_, err := GetTextSplitter("text", "invalid")
 	assert.Error(t, err)
 }
 
 func TestGetTextSplitterFuncWithValidNameAndValidConfig(t *testing.T) {
-	_, err := GetTextSplitterFunc("text", NewTextSplitterOpts())
+	_, err := GetTextSplitter("text", NewTextSplitterOpts())
 	assert.NoError(t, err)
 }
 
 func TestGetTextSplitterFuncWithInvalidName(t *testing.T) {
-	_, err := GetTextSplitterFunc("invalid", nil)
+	_, err := GetTextSplitter("invalid", nil)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
```yaml
flows:
  chatgpt:
    default: true
    globals:
      ingestion:
        textsplitter: # settings which will be merged with the config for any textsplitter implementation
          chunkSize: 800
          chunkOverlap: 400
    ingestion:
      - filetypes: ["*"]
        textsplitter:
          name: text
          options:
            chunkSize: 811
```