### PR TITLE
fix: do not error on unsupported file types by default upon ingestion - but add --err-on-unsupported-file flag to toggle that behavior

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/textsplitter"
 	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
@@ -11,16 +12,17 @@ import (
 )
 
 type IngestPathsOpts struct {
-	IgnoreExtensions    []string
-	Concurrency         int
-	Recursive           bool
-	TextSplitterOpts    *textsplitter.TextSplitterOpts
-	IngestionFlows      []flows.IngestionFlow
-	IgnoreFile          string
-	IncludeHidden       bool
-	NoCreateDataset     bool
-	IsDuplicateFuncName string
-	Prune               bool // Prune deleted files
+	IgnoreExtensions     []string
+	Concurrency          int
+	Recursive            bool
+	TextSplitterOpts     *textsplitter.TextSplitterOpts
+	IngestionFlows       []flows.IngestionFlow
+	IgnoreFile           string
+	IncludeHidden        bool
+	NoCreateDataset      bool
+	IsDuplicateFuncName  string
+	Prune                bool // Prune deleted files
+	ErrOnUnsupportedFile bool
 }
 
 type Client interface {

--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -6,6 +6,11 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	remotes "github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/remote"
@@ -13,10 +18,6 @@ import (
 	"github.com/gptscript-ai/knowledge/pkg/index"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 func isIgnored(ignore gitignore.Matcher, path string) bool {

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
 	"os"
 	"path/filepath"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader"
+	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
 
 	"github.com/acorn-io/z"
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
@@ -100,6 +103,11 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 		}
 
 		_, err = c.Ingest(ctx, datasetID, file, iopts)
+
+		if err != nil && !opts.ErrOnUnsupportedFile && errors.Is(err, &documentloader.UnsupportedFileTypeError{}) {
+			err = nil
+		}
+
 		return err
 	}
 

--- a/pkg/cmd/askdir.go
+++ b/pkg/cmd/askdir.go
@@ -43,13 +43,14 @@ func (s *ClientAskDir) Run(cmd *cobra.Command, args []string) error {
 	query := args[0]
 
 	ingestOpts := &client.IngestPathsOpts{
-		IgnoreExtensions:    strings.Split(s.IgnoreExtensions, ","),
-		Concurrency:         s.Concurrency,
-		Recursive:           !s.NoRecursive,
-		IgnoreFile:          s.IgnoreFile,
-		IncludeHidden:       s.IncludeHidden,
-		IsDuplicateFuncName: s.DeduplicationFuncName,
-		Prune:               !s.NoPrune,
+		IgnoreExtensions:     strings.Split(s.IgnoreExtensions, ","),
+		Concurrency:          s.Concurrency,
+		Recursive:            !s.NoRecursive,
+		IgnoreFile:           s.IgnoreFile,
+		IncludeHidden:        s.IncludeHidden,
+		IsDuplicateFuncName:  s.DeduplicationFuncName,
+		Prune:                !s.NoPrune,
+		ErrOnUnsupportedFile: s.ErrOnUnsupportedFile,
 	}
 
 	retrieveOpts := &datastore.RetrieveOpts{

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 	"log/slog"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings"
 
 	"github.com/acorn-io/z"
 	"github.com/google/uuid"
@@ -142,7 +144,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, content []byte
 	}
 
 	if ingestionFlow.Load == nil {
-		return nil, fmt.Errorf("unsupported filetype %q (file %q)", filetype, opts.FileMetadata.AbsolutePath)
+		return nil, fmt.Errorf("%w (file %q)", &documentloader.UnsupportedFileTypeError{FileType: filetype}, opts.FileMetadata.AbsolutePath)
 	}
 
 	// Mandatory Transformation: Add filename to metadata


### PR DESCRIPTION
Regression introduced by #72 

`--err-on-unsupported-file` is **always** `true` when ingesting a single file, but `false` **by default** for directories