### PR TITLE
add: merging retriever with example for hybrid search using bm25 and semantic search

### DIFF
--- a/examples/hybrid-retriever.yaml
+++ b/examples/hybrid-retriever.yaml
@@ -1,0 +1,22 @@
+flows:
+  hybrid:
+    default: true
+    retrieval:
+      retriever:
+        name: merge
+        options:
+          topK: 10
+          retrievers:
+            - name: basic
+              weight: 0.5
+              options:
+                topK: 10
+            - name: bm25
+              weight: 0.5
+              options:
+                topN: 10
+                k1: 1.2
+                b: 0.75
+                cleanStopWords:
+                  - en
+                  - de

--- a/pkg/datastore/lib/scores/scores.go
+++ b/pkg/datastore/lib/scores/scores.go
@@ -1,0 +1,48 @@
+package scores
+
+import (
+	"log/slog"
+	"math"
+
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+)
+
+func FindMinMaxScores(docs []vs.Document) (float32, float32) {
+	minScore, maxScore := float32(math.MaxFloat32), float32(-math.MaxFloat32)
+
+	// Find min and max scores
+	for _, doc := range docs {
+		score := doc.SimilarityScore
+		if score < minScore {
+			minScore = score
+		}
+		if score > maxScore {
+			maxScore = score
+		}
+	}
+
+	return minScore, maxScore
+}
+
+// NormalizeDocScores normalizes scores to a 0-1 range
+func NormalizeDocScores(docs []vs.Document) []vs.Document {
+	minScore, maxScore := FindMinMaxScores(docs)
+
+	// Normalize scores
+	for i, doc := range docs {
+		normalizedScore := NormalizeScore(doc.SimilarityScore, minScore, maxScore)
+		slog.Debug("Normalized similarity score", "score", doc.SimilarityScore, "normalized_score", normalizedScore)
+		docs[i].SimilarityScore = normalizedScore
+	}
+
+	return docs
+}
+
+// NormalizeScore normalizes a single score
+func NormalizeScore(score float32, minScore float32, maxScore float32) float32 {
+	if maxScore-minScore == 0 {
+		return 0 // Avoid division by zero
+	}
+	normalizedScore := (score - minScore) / (maxScore - minScore)
+	return normalizedScore
+}

--- a/pkg/datastore/retrievers/merging.go
+++ b/pkg/datastore/retrievers/merging.go
@@ -2,10 +2,15 @@ package retrievers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"slices"
 
+	"github.com/acorn-io/z"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/lib/scores"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/store"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
+	"github.com/mitchellh/mapstructure"
 	"github.com/philippgille/chromem-go"
 )
 
@@ -13,38 +18,95 @@ const MergingRetrieverName = "merge"
 
 type MergingRetriever struct {
 	TopK       int
-	Retrievers []Retriever `json:"retrievers" mapstructure:"retrievers" yaml:"retrievers"`
+	Retrievers []RetrieverToMerge `json:"retrievers" mapstructure:"retrievers" yaml:"retrievers"`
+	retrievers []Retriever
+}
+
+type RetrieverToMerge struct {
+	Name    string         `json:"name,omitempty" mapstructure:"name" yaml:"name"`
+	Weight  *float32       `json:"weight,omitempty" mapstructure:"weight" yaml:"weight"`
+	Options map[string]any `json:"options,omitempty" mapstructure:"options" yaml:"options"`
 }
 
 func (r *MergingRetriever) Name() string {
 	return MergingRetrieverName
 }
+
+func (r *MergingRetriever) DecodeConfig(cfg map[string]any) error {
+	if err := mapstructure.Decode(cfg, &r); err != nil {
+		return fmt.Errorf("failed to decode merging retriever configuration: %w", err)
+	}
+
+	r.retrievers = make([]Retriever, len(r.Retrievers))
+	for i, retrieverConfig := range r.Retrievers {
+		retriever, err := GetRetriever(retrieverConfig.Name)
+		if err != nil {
+			return err
+		}
+		if err := retriever.DecodeConfig(retrieverConfig.Options); err != nil {
+			return err
+		}
+		r.retrievers[i] = retriever
+	}
+
+	return nil
+}
+
 func (r *MergingRetriever) Retrieve(ctx context.Context, store store.Store, query string, datasetIDs []string, where map[string]string, whereDocument []chromem.WhereDocument) ([]vs.Document, error) {
 	log := slog.With("component", "MergingRetriever")
 
-	var docs []vs.Document
-	for _, retriever := range r.Retrievers {
-		log.Debug("Retrieving documents from retriever", "retriever", retriever.Name())
-		docsRetriever, err := retriever.Retrieve(ctx, store, query, datasetIDs, where, whereDocument)
-		if err != nil {
-			log.Error("Failed to retrieve documents from retriever", "retriever", retriever.Name(), "error", err)
-			return nil, err
-		}
-
-	docLoop:
-		for _, doc := range docs {
-			// check if	doc is already in docs and if so, update similarity score if higher
-			for i, r := range docsRetriever {
-				if doc.ID == r.ID {
-					if doc.SimilarityScore > r.SimilarityScore {
-						docs[i].SimilarityScore = doc.SimilarityScore
-						continue docLoop
-					}
-				}
-			}
-			docs = append(docs, doc)
+	// Set default weight to 1.0 if not provided
+	for i, retriever := range r.Retrievers {
+		if retriever.Weight == nil {
+			r.Retrievers[i].Weight = z.Pointer(float32(1.0))
 		}
 	}
 
-	return docs[:r.TopK-1], nil
+	var resultDocs []vs.Document
+	for ri, retriever := range r.Retrievers {
+		log.Debug("Retrieving documents from retriever", "retriever", retriever.Name)
+		retrievedDocs, err := r.retrievers[ri].Retrieve(ctx, store, query, datasetIDs, where, whereDocument)
+		if err != nil {
+			log.Error("Failed to retrieve documents from retriever", "retriever", retriever.Name, "error", err)
+			return nil, err
+		}
+
+		min, max := scores.FindMinMaxScores(retrievedDocs)
+
+	docLoop:
+		for _, retrievedDoc := range retrievedDocs {
+			for i, resultDoc := range resultDocs {
+				// check if	resultDoc is already in resultDocs and if so, update similarity score if higher
+				if resultDoc.ID == retrievedDoc.ID {
+					// Note that this was found by another retriever and note it's similarityScore
+					resultDocs[i].Metadata["retriever"] = fmt.Sprintf("%s,%s", resultDocs[i].Metadata["retriever"], retriever.Name)
+					resultDocs[i].Metadata["retrieverScore::"+retriever.Name] = retrievedDoc.SimilarityScore
+					normalizedScore := scores.NormalizeScore(retrievedDoc.SimilarityScore, min, max)
+					resultDocs[i].Metadata["retrieverScoreNormalized::"+retriever.Name] = normalizedScore
+					resultDocs[i].SimilarityScore += normalizedScore * z.Dereference(retriever.Weight)
+					continue docLoop
+				}
+			}
+			// not in resultDocs yet, add it
+			retrievedDoc.Metadata["retriever"] = retriever.Name
+			retrievedDoc.Metadata["retrieverScore::"+retriever.Name] = retrievedDoc.SimilarityScore
+			normalizedScore := scores.NormalizeScore(retrievedDoc.SimilarityScore, min, max)
+			retrievedDoc.Metadata["retrieverScoreNormalized::"+retriever.Name] = normalizedScore
+			retrievedDoc.SimilarityScore = normalizedScore * z.Dereference(retriever.Weight)
+			resultDocs = append(resultDocs, retrievedDoc)
+		}
+	}
+
+	// Sort the resultDocs by similarity score
+	slices.SortFunc(resultDocs, func(i, j vs.Document) int {
+		if i.SimilarityScore > j.SimilarityScore {
+			return -1
+		}
+		if i.SimilarityScore < j.SimilarityScore {
+			return 1
+		}
+		return 0
+	})
+
+	return resultDocs[:r.TopK-1], nil
 }

--- a/pkg/datastore/retrievers/routing.go
+++ b/pkg/datastore/retrievers/routing.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/defaults"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/store"
 	"github.com/gptscript-ai/knowledge/pkg/llm"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"github.com/philippgille/chromem-go"
-	"log/slog"
 )
 
 const RoutingRetrieverName = "routing"
@@ -22,6 +23,10 @@ type RoutingRetriever struct {
 
 func (r *RoutingRetriever) Name() string {
 	return RoutingRetrieverName
+}
+
+func (r *RoutingRetriever) DecodeConfig(cfg map[string]any) error {
+	return DefaultConfigDecoder(r, cfg)
 }
 
 var routingPromptTpl = `The following query will be used for a vector similarity search.

--- a/pkg/datastore/retrievers/subquery.go
+++ b/pkg/datastore/retrievers/subquery.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"strings"
+
 	"github.com/gptscript-ai/knowledge/pkg/datastore/store"
 	"github.com/gptscript-ai/knowledge/pkg/llm"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 	"github.com/philippgille/chromem-go"
-	"log/slog"
-	"strings"
 )
 
 const SubqueryRetrieverName = "subquery"
@@ -20,8 +21,12 @@ type SubqueryRetriever struct {
 	TopK  int
 }
 
-func (s SubqueryRetriever) Name() string {
+func (s *SubqueryRetriever) Name() string {
 	return SubqueryRetrieverName
+}
+
+func (s *SubqueryRetriever) DecodeConfig(cfg map[string]any) error {
+	return DefaultConfigDecoder(s, cfg)
 }
 
 var subqueryPrompt = `The following query will be used for a vector similarity search.
@@ -38,7 +43,7 @@ type subqueryResp struct {
 	Results []string `json:"results"`
 }
 
-func (s SubqueryRetriever) Retrieve(ctx context.Context, store store.Store, query string, datasetIDs []string, where map[string]string, whereDocument []chromem.WhereDocument) ([]vs.Document, error) {
+func (s *SubqueryRetriever) Retrieve(ctx context.Context, store store.Store, query string, datasetIDs []string, where map[string]string, whereDocument []chromem.WhereDocument) ([]vs.Document, error) {
 
 	if len(datasetIDs) > 1 {
 		return nil, fmt.Errorf("basic retriever does not support querying multiple datasets")

--- a/pkg/flows/config/config.go
+++ b/pkg/flows/config/config.go
@@ -285,7 +285,7 @@ func (r *RetrievalFlowConfig) AsRetrievalFlow() (*flows.RetrievalFlow, error) {
 			return nil, err
 		}
 		if len(r.Retriever.Options) > 0 {
-			if err := mapstructure.Decode(r.Retriever.Options, &ret); err != nil {
+			if err := ret.DecodeConfig(r.Retriever.Options); err != nil {
 				return nil, fmt.Errorf("failed to decode retriever configuration: %w", err)
 			}
 			slog.Debug("Retriever custom configuration", "name", r.Retriever.Name, "config", output.RedactSensitive(ret))

--- a/pkg/output/redact.go
+++ b/pkg/output/redact.go
@@ -38,13 +38,13 @@ func RedactSensitive(s any, fields ...string) any {
 		fieldName := strings.ToLower(fieldType.Name)
 
 		// Skip unexported fields
-		if !field.CanSet() {
+		if !fieldType.IsExported() {
 			continue
 		}
 
 		// Handle nested structs recursively
 		if field.Kind() == reflect.Struct {
-			redactedStruct.Field(i).Set(reflect.ValueOf(RedactSensitive(field.Interface())))
+			redactedStruct.Field(i).Set(reflect.ValueOf(RedactSensitive(field.Interface(), toRedact...)))
 			continue
 		}
 

--- a/pkg/output/redact.go
+++ b/pkg/output/redact.go
@@ -37,6 +37,11 @@ func RedactSensitive(s any, fields ...string) any {
 		fieldType := v.Type().Field(i)
 		fieldName := strings.ToLower(fieldType.Name)
 
+		// Skip unexported fields
+		if !field.CanSet() {
+			continue
+		}
+
 		// Handle nested structs recursively
 		if field.Kind() == reflect.Struct {
 			redactedStruct.Field(i).Set(reflect.ValueOf(RedactSensitive(field.Interface())))


### PR DESCRIPTION


Example flow config:

```yaml
flows:
  hybrid:
    default: true
    retrieval:
      retriever:
        name: merge
        options:
          topK: 10
          retrievers:
            - name: basic
              weight: 0.5
              options:
                topK: 10
            - name: bm25
              weight: 0.5
              options:
                topN: 10
                k1: 1.2
                b: 0.75
                cleanStopWords:
                  - en
                  - de
```