### PR TITLE
add: metadata-manipulator transformer & post-processor

### DIFF
--- a/examples/no-filenames.yaml
+++ b/examples/no-filenames.yaml
@@ -1,0 +1,17 @@
+flows:
+  bm25:
+    default: true
+    retrieval:
+      retriever:
+        name: basic
+        options:
+          topK: 1
+      postprocessors:
+        - name: metadata
+          options:
+            manipulations:
+              - operator: add
+                key: foobar
+                value: 42
+              - operator: remove
+                key: absPath

--- a/pkg/datastore/transformers/metadata.go
+++ b/pkg/datastore/transformers/metadata.go
@@ -2,6 +2,8 @@ package transformers
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore"
 )
@@ -13,14 +15,66 @@ type ExtraMetadata struct {
 }
 
 func (e *ExtraMetadata) Transform(_ context.Context, docs []vs.Document) ([]vs.Document, error) {
-	for _, doc := range docs {
+	for i, doc := range docs {
+		metadata := doc.Metadata
 		for k, v := range e.Metadata {
-			doc.Metadata[k] = v
+			metadata[k] = v
 		}
+		docs[i].Metadata = metadata
 	}
 	return docs, nil
 }
 
 func (e *ExtraMetadata) Name() string {
 	return ExtraMetadataName
+}
+
+const MetadataManipulatorName = "metadata"
+
+type MetadataManipulationOperator string
+
+const (
+	MetadataManipulationOperatorAdd    MetadataManipulationOperator = "add"
+	MetadataManipulationOperatorUpdate MetadataManipulationOperator = "upsert"
+	MetadataManipulationOperatorRemove MetadataManipulationOperator = "remove"
+)
+
+type MetadataManipulation struct {
+	Operator MetadataManipulationOperator `json:"operator,omitempty" mapstructure:"operator"`
+	Key      string                       `json:"key,omitempty" mapstructure:"key"`
+	Value    any                          `json:"value,omitempty" mapstructure:"value"`
+}
+
+type MetadataManipulator struct {
+	Manipulations []MetadataManipulation
+}
+
+func (m *MetadataManipulator) Name() string {
+	return MetadataManipulatorName
+}
+
+func (m *MetadataManipulator) Transform(_ context.Context, docs []vs.Document) ([]vs.Document, error) {
+	for i, doc := range docs {
+		metadata := doc.Metadata
+		if metadata == nil {
+			metadata = make(map[string]any)
+		}
+		slog.Debug("metadata manipulator", "docMetadata", metadata, "manipulations", m.Manipulations)
+		for _, manipulation := range m.Manipulations {
+			switch manipulation.Operator {
+			case MetadataManipulationOperatorAdd:
+				if _, exists := metadata[manipulation.Key]; exists {
+					return nil, fmt.Errorf("metadata key %q already exists in document", manipulation.Key)
+				}
+				metadata[manipulation.Key] = manipulation.Value
+			case MetadataManipulationOperatorUpdate:
+				metadata[manipulation.Key] = manipulation.Value
+			case MetadataManipulationOperatorRemove:
+				delete(metadata, manipulation.Key)
+			}
+		}
+		slog.Debug("metadata manipulator DONE", "docMetadata", metadata)
+		docs[i].Metadata = metadata
+	}
+	return docs, nil
 }

--- a/pkg/datastore/transformers/transformers.go
+++ b/pkg/datastore/transformers/transformers.go
@@ -10,6 +10,7 @@ var TransformerMap = map[string]types.DocumentTransformer{
 	ExtraMetadataName:               &ExtraMetadata{},
 	FilterMarkdownDocsNoContentName: &FilterMarkdownDocsNoContent{},
 	KeywordExtractorName:            &KeywordExtractor{},
+	MetadataManipulatorName:         &MetadataManipulator{},
 }
 
 func GetTransformer(name string) (types.DocumentTransformer, error) {


### PR DESCRIPTION
Example:

```
flows:
  bm25:
    default: true
    retrieval:
      retriever:
        name: basic
        options:
          topK: 1
      postprocessors:
        - name: metadata
          options:
            manipulations:
              - operator: add
                key: foobar
                value: 42
              - operator: remove
                key: absPath
```