### PR TITLE
fix-bundle

### DIFF
--- a/pkg/cmd/ingest.go
+++ b/pkg/cmd/ingest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/acorn-io/z"
@@ -62,7 +63,7 @@ func (s *ClientIngest) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !finfo.IsDir() {
+	if !finfo.IsDir() && path.Ext(filePath) != ".zip" {
 		slog.Debug("ingesting single file, setting err-on-unsupported-file to true", "file", filePath)
 		s.ErrOnUnsupportedFile = true
 	}

--- a/pkg/cmd/retrieve.go
+++ b/pkg/cmd/retrieve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/gptscript-ai/knowledge/pkg/datastore"
 	flowconfig "github.com/gptscript-ai/knowledge/pkg/flows/config"
@@ -32,16 +33,27 @@ func (s *ClientRetrieve) Customize(cmd *cobra.Command) {
 }
 
 func (s *ClientRetrieve) Run(cmd *cobra.Command, args []string) error {
-	c, err := s.getClient()
-	if err != nil {
-		return err
+	query := strings.TrimSpace(args[0])
+
+	if query == "" {
+		fmt.Println("Query is empty - not retrieving anything.")
+		return fmt.Errorf("empty query")
+	}
+	slog.Info("Retrieving sources for query", "query", query)
+
+	if query == "-" {
+		return nil
 	}
 
 	datasetIDs := s.Datasets
 	if len(s.Datasets) == 0 {
 		datasetIDs = []string{"default"}
 	}
-	query := args[0]
+
+	c, err := s.getClient()
+	if err != nil {
+		return err
+	}
 
 	retrieveOpts := datastore.RetrieveOpts{
 		TopK:     s.TopK,

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -4,16 +4,17 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/config"
-	etypes "github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/types"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
-	"github.com/gptscript-ai/knowledge/pkg/output"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/gptscript-ai/knowledge/pkg/config"
+	etypes "github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/types"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/types"
+	"github.com/gptscript-ai/knowledge/pkg/output"
 
 	"github.com/adrg/xdg"
 	"github.com/gptscript-ai/knowledge/pkg/index"
@@ -101,7 +102,7 @@ func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingPr
 		return nil, fmt.Errorf("failed to create embedding function: %w", err)
 	}
 
-	slog.Info("Using embedding model provider", "provider", embeddingProvider.Name(), "config", output.RedactSensitive(embeddingProvider.Config()))
+	slog.Debug("Using embedding model provider", "provider", embeddingProvider.Name(), "config", output.RedactSensitive(embeddingProvider.Config()))
 
 	ds := &Datastore{
 		Index:                  idx,

--- a/pkg/datastore/lib/scores/scores.go
+++ b/pkg/datastore/lib/scores/scores.go
@@ -41,7 +41,7 @@ func NormalizeDocScores(docs []vs.Document) []vs.Document {
 // NormalizeScore normalizes a single score
 func NormalizeScore(score float32, minScore float32, maxScore float32) float32 {
 	if maxScore-minScore == 0 {
-		return 0 // Avoid division by zero
+		return 1 // Avoid division by zero - also, this happens for a single document, so we want a score of 1 here
 	}
 	normalizedScore := (score - minScore) / (maxScore - minScore)
 	return normalizedScore

--- a/pkg/datastore/postprocessors/bm25.go
+++ b/pkg/datastore/postprocessors/bm25.go
@@ -67,7 +67,12 @@ func (c *BM25Postprocessor) transform(ctx context.Context, query string, docs []
 		return docs[i].Metadata["combinedScore"].(float64) > docs[i].Metadata["combinedScore"].(float64)
 	})
 
-	return docs[:c.TopN-1], nil
+	topN := c.TopN
+	if topN > len(docs) {
+		topN = len(docs)
+	}
+
+	return docs[:topN], nil
 }
 
 func (c *BM25Postprocessor) Name() string {

--- a/pkg/datastore/postprocessors/reduce.go
+++ b/pkg/datastore/postprocessors/reduce.go
@@ -35,13 +35,13 @@ func (s *ReducePostprocessor) Transform(ctx context.Context, response *types.Ret
 		})
 
 		if topK > len(docs) {
-			topK = len(docs) - 1
+			topK = len(docs)
 		}
 		if topK <= 0 {
 			continue
 		}
 
-		slog.Debug("Reducing topK", "topK", topK, "len(docs)", len(docs))
+		slog.Info("Reducing topK", "topK", topK, "len(docs)", len(docs))
 
 		response.Responses[q] = docs[:topK]
 	}

--- a/pkg/datastore/retrievers/bm25.go
+++ b/pkg/datastore/retrievers/bm25.go
@@ -65,5 +65,11 @@ func (r *BM25Retriever) Retrieve(ctx context.Context, store store.Store, query s
 		return 0
 	})
 
-	return docs[:r.TopN-1], nil
+	topN := r.TopN
+	if topN > len(docs) {
+		topN = len(docs)
+	}
+
+	return docs[:topN-1], nil
+
 }

--- a/pkg/flows/flows.go
+++ b/pkg/flows/flows.go
@@ -3,13 +3,14 @@ package flows
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+
 	"github.com/acorn-io/z"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/store"
 	"github.com/mitchellh/mapstructure"
 	"github.com/philippgille/chromem-go"
-	"io"
-	"log/slog"
-	"slices"
 
 	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/postprocessors"
@@ -60,7 +61,10 @@ func (f *IngestionFlow) SupportsFiletype(filetype string) bool {
 
 func (f *IngestionFlow) FillDefaults(filetype string, textsplitterOpts *textsplitter.TextSplitterOpts) error {
 	if f.Load == nil {
-		f.Load = documentloader.DefaultDocLoaderFunc(filetype)
+		f.Load = documentloader.DefaultDocLoaderFunc(filetype, documentloader.DefaultDocLoaderFuncOpts{Archive: documentloader.ArchiveOpts{
+			ErrOnUnsupportedFiletype: false,
+			ErrOnFailedFile:          false,
+		}})
 	}
 	if f.Splitter == nil {
 		if textsplitterOpts == nil {

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -3,8 +3,9 @@ package llm
 import (
 	"context"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/openai"
 	"log/slog"
+
+	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/openai"
 
 	golcmodel "github.com/hupe1980/golc/model"
 	"github.com/hupe1980/golc/model/chatmodel"


### PR DESCRIPTION
[fix: do not error on unsupported file if single target file is a ZIP](https://github.com/gptscript-ai/knowledge/commit/8955779e985f5e66baaeef88a2f7eac9446dfa31)

[change (retrieve): error on empty query, but just return nothing on '-' as query](https://github.com/gptscript-ai/knowledge/commit/c79c306f0d4993c47cda1b168ce1ad3e8ca087ec)

[change: reduce log spam](https://github.com/gptscript-ai/knowledge/commit/16bd934c198d60f96b124eeb9ad0d67b5e287e7c)

[fix: by default, do not error on unsupported or broken files within an archive](https://github.com/gptscript-ai/knowledge/commit/a9e95df23bc145949b37c171c8f1ed1955b84bb9)

[fix: topK result set reduction was broken (cutoff of last element)](https://github.com/gptscript-ai/knowledge/commit/50c9d7b8b261d6c76fa0bf452f4dbc5c5c3aebe5)
