### PR TITLE
fix: do not min/max-normalize already normalized similarity scores to not distort them

### DIFF
--- a/pkg/datastore/lib/scores/scores.go
+++ b/pkg/datastore/lib/scores/scores.go
@@ -40,6 +40,9 @@ func NormalizeDocScores(docs []vs.Document) []vs.Document {
 
 // NormalizeScore normalizes a single score
 func NormalizeScore(score float32, minScore float32, maxScore float32) float32 {
+	if maxScore == 0 {
+		return 0
+	}
 	if maxScore-minScore == 0 {
 		return 1 // Avoid division by zero - also, this happens for a single document, so we want a score of 1 here
 	}

--- a/pkg/datastore/retrievers/bm25.go
+++ b/pkg/datastore/retrievers/bm25.go
@@ -29,6 +29,10 @@ func (r *BM25Retriever) Name() string {
 	return BM25RetrieverName
 }
 
+func (r *BM25Retriever) NormalizedScores() bool {
+	return false
+}
+
 func (r *BM25Retriever) DecodeConfig(cfg map[string]any) error {
 	return DefaultConfigDecoder(r, cfg)
 }

--- a/pkg/datastore/retrievers/retrievers.go
+++ b/pkg/datastore/retrievers/retrievers.go
@@ -21,6 +21,7 @@ type Retriever interface {
 	Retrieve(ctx context.Context, store store.Store, query string, datasetIDs []string, where map[string]string, whereDocument []chromem.WhereDocument) ([]vs.Document, error)
 	Name() string
 	DecodeConfig(cfg map[string]any) error
+	NormalizedScores() bool // whether the retriever returns normalized scores
 }
 
 func GetRetriever(name string) (Retriever, error) {
@@ -66,6 +67,10 @@ type BasicRetriever struct {
 
 func (r *BasicRetriever) Name() string {
 	return BasicRetrieverName
+}
+
+func (r *BasicRetriever) NormalizedScores() bool {
+	return true
 }
 
 func (r *BasicRetriever) DecodeConfig(cfg map[string]any) error {

--- a/pkg/datastore/retrievers/routing.go
+++ b/pkg/datastore/retrievers/routing.go
@@ -25,6 +25,10 @@ func (r *RoutingRetriever) Name() string {
 	return RoutingRetrieverName
 }
 
+func (r *RoutingRetriever) NormalizedScores() bool {
+	return true
+}
+
 func (r *RoutingRetriever) DecodeConfig(cfg map[string]any) error {
 	return DefaultConfigDecoder(r, cfg)
 }

--- a/pkg/datastore/retrievers/subquery.go
+++ b/pkg/datastore/retrievers/subquery.go
@@ -28,6 +28,10 @@ func (s *SubqueryRetriever) Name() string {
 	return SubqueryRetrieverName
 }
 
+func (s *SubqueryRetriever) NormalizedScores() bool {
+	return true
+}
+
 func (s *SubqueryRetriever) DecodeConfig(cfg map[string]any) error {
 	return DefaultConfigDecoder(s, cfg)
 }


### PR DESCRIPTION
In our default flows, we're using a merging retriever with similarity search and bm25 search.
The similarityScores from the similarity search are already normalized (0-1 range), while the bm25 Scores are not.
Before this change we still did a min/max-normalization even over the observed similarityScores, which distorted them so much that it significantly impacted the merged document score.

For the future we may consider using zScore normalization - #106 