### PR TITLE
feat: ingestion - include metadata from .knowledge.json on dir level

### DIFF
--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
@@ -20,38 +19,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-func isIgnored(ignore gitignore.Matcher, path string) bool {
-	return ignore.Match(strings.Split(path, string(filepath.Separator)), false)
-}
-
-func readIgnoreFile(path string) ([]gitignore.Pattern, error) {
-	stat, err := os.Stat(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to checkout ignore file %q: %w", path, err)
-	}
-
-	if stat.IsDir() {
-		return nil, fmt.Errorf("ignore file %q is a directory", path)
-	}
-
-	var ps []gitignore.Pattern
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open ignore file %q: %w", path, err)
-	}
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		s := scanner.Text()
-		if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
-			ps = append(ps, gitignore.ParsePattern(s, nil))
-		}
-	}
-
-	return ps, nil
-}
-
-func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID string, ingestionFunc func(path string) error, paths ...string) (int, error) {
+func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID string, ingestionFunc func(path string, metadata map[string]any) error, paths ...string) (int, error) {
 	ingestedFilesCount := 0
 
 	var ignorePatterns []gitignore.Pattern
@@ -72,7 +40,7 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 		}
 	}
 
-	slog.Debug("Ignore patterns", "patterns", ignorePatterns, "len", len(ignorePatterns))
+	ignorePatterns = append(ignorePatterns, DefaultIgnorePatterns...)
 
 	ignore := gitignore.NewMatcher(ignorePatterns)
 
@@ -82,6 +50,9 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 	sem := semaphore.NewWeighted(int64(opts.Concurrency)) // limit max. concurrency
 
 	g, ctx := errgroup.WithContext(ctx)
+
+	// Stack to store metadata when entering nested directories
+	var metadataStack []map[string]any
 
 	for _, p := range paths {
 		path := p
@@ -109,6 +80,13 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 		}
 
 		if fileInfo.IsDir() {
+			initialMetadata := map[string]any{}
+			directoryMetadata, err := loadAndMergeMetadata(path, initialMetadata)
+			if err != nil {
+				return ingestedFilesCount, err
+			}
+			metadataStack = append(metadataStack, directoryMetadata)
+
 			// Process directory
 			err = filepath.WalkDir(path, func(subPath string, d os.DirEntry, err error) error {
 				if err != nil {
@@ -121,6 +99,14 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 					if !opts.Recursive {
 						return filepath.SkipDir // Skip subdirectories if not recursive
 					}
+
+					// One dir level deeper -> load new metadata
+					parentMetadata := metadataStack[len(metadataStack)-1]
+					newMetadata, err := loadAndMergeMetadata(subPath, parentMetadata)
+					if err != nil {
+						return err
+					}
+					metadataStack = append(metadataStack, newMetadata)
 					return nil
 				}
 				if isIgnored(ignore, subPath) {
@@ -128,12 +114,16 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 					return nil
 				}
 
+				// Process the file
 				sp := subPath
 				absPath, err := filepath.Abs(sp)
 				if err != nil {
 					return fmt.Errorf("failed to get absolute path for %s: %w", sp, err)
 				}
 				touchedFilePaths = append(touchedFilePaths, absPath)
+
+				currentMetadata := metadataStack[len(metadataStack)-1]
+
 				g.Go(func() error {
 					if err := sem.Acquire(ctx, 1); err != nil {
 						return err
@@ -141,14 +131,16 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 					defer sem.Release(1)
 
 					ingestedFilesCount++
-					slog.Debug("Ingesting file", "path", absPath)
-					return ingestionFunc(sp)
+					slog.Debug("Ingesting file", "path", absPath, "metadata", currentMetadata)
+					return ingestionFunc(sp, currentMetadata)
 				})
 				return nil
 			})
 			if err != nil {
 				return ingestedFilesCount, err
 			}
+			// Directory processed, pop metadata
+			metadataStack = metadataStack[:len(metadataStack)-1]
 		} else {
 			if isIgnored(ignore, path) {
 				slog.Debug("Ignoring file", "path", path, "ignorefile", opts.IgnoreFile, "ignoreExtensions", opts.IgnoreExtensions)
@@ -168,7 +160,8 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 				defer sem.Release(1)
 
 				ingestedFilesCount++
-				return ingestionFunc(path)
+				currentMetadata := metadataStack[len(metadataStack)-1]
+				return ingestionFunc(path, currentMetadata)
 			})
 		}
 

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
-
 	"github.com/acorn-io/z"
 	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
 

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
+
 	"github.com/acorn-io/z"
 	dstypes "github.com/gptscript-ai/knowledge/pkg/datastore/types"
 
@@ -122,7 +124,7 @@ func (c *DefaultClient) IngestPaths(ctx context.Context, datasetID string, opts 
 		return 0, err
 	}
 
-	ingestFile := func(path string) error {
+	ingestFile := func(path string, extraMetadata map[string]any) error {
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", path, err)
@@ -148,6 +150,7 @@ func (c *DefaultClient) IngestPaths(ctx context.Context, datasetID string, opts 
 				ModifiedAt:   finfo.ModTime(),
 			},
 			IsDuplicateFuncName: "file_metadata",
+			ExtraMetadata:       extraMetadata,
 		}
 		if opts != nil {
 			payload.TextSplitterOpts = opts.TextSplitterOpts

--- a/pkg/client/ignore.go
+++ b/pkg/client/ignore.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+var DefaultIgnorePatterns = []gitignore.Pattern{
+	gitignore.ParsePattern(MetadataFilename, nil), // Knowledge Metadata file
+	gitignore.ParsePattern("~$*", nil),            // MS Office temp files
+	gitignore.ParsePattern("$*", nil),             // Likely hidden/tempfiles
+}
+
+func isIgnored(ignore gitignore.Matcher, path string) bool {
+	return ignore.Match(strings.Split(path, string(filepath.Separator)), false)
+}
+
+func readIgnoreFile(path string) ([]gitignore.Pattern, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to checkout ignore file %q: %w", path, err)
+	}
+
+	if stat.IsDir() {
+		return nil, fmt.Errorf("ignore file %q is a directory", path)
+	}
+
+	var ps []gitignore.Pattern
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open ignore file %q: %w", path, err)
+	}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		s := scanner.Text()
+		if !strings.HasPrefix(s, "#") && len(strings.TrimSpace(s)) > 0 {
+			ps = append(ps, gitignore.ParsePattern(s, nil))
+		}
+	}
+
+	return ps, nil
+}

--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -32,7 +32,7 @@ func loadAndMergeMetadata(dirPath string, parentMetadata *Metadata) (*Metadata, 
 		}
 
 		// Merge with parent metadata, overriding existing keys
-		mergedMetadata := &Metadata{Metadata: map[string]FileMetadata{}}
+		mergedMetadata := &Metadata{Metadata: make(map[string]FileMetadata, len(parentMetadata.Metadata)+len(newMetadata.Metadata))}
 		for filename, fileMetadata := range parentMetadata.Metadata {
 			if !strings.HasPrefix(filename, dirName) {
 				// skip entries which are not meant for this (sub-)directory
@@ -46,7 +46,7 @@ func loadAndMergeMetadata(dirPath string, parentMetadata *Metadata) (*Metadata, 
 			for filename, fileMetadata := range newMetadata.Metadata {
 				for k, v := range fileMetadata {
 					if mergedMetadata.Metadata[filename] == nil {
-						mergedMetadata.Metadata[filename] = map[string]any{}
+						mergedMetadata.Metadata[filename] = make(FileMetadata, len(fileMetadata))
 					}
 					mergedMetadata.Metadata[filename][k] = v
 				}

--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -5,35 +5,52 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const MetadataFilename = ".knowledge.json"
 
 type Metadata struct {
-	Metadata map[string]any `json:"metadata"`
+	Metadata map[string]FileMetadata `json:"metadata"` // Map of file paths to metadata
 	// TODO (idea): add other fields like description here, so we can hierarchically build a dataset description? Challenge is pruning and merging.
 }
 
-func loadAndMergeMetadata(dirPath string, parentMetadata map[string]any) (map[string]any, error) {
+type FileMetadata map[string]any
+
+func loadAndMergeMetadata(dirPath string, parentMetadata *Metadata) (*Metadata, error) {
 	metadataPath := filepath.Join(dirPath, MetadataFilename)
+	dirName := filepath.Base(dirPath)
 	if _, err := os.Stat(metadataPath); err == nil { // Metadata file exists
 		fileContent, err := os.ReadFile(metadataPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read metadata file %s: %w", metadataPath, err)
 		}
 
-		var newMetadata map[string]any
+		var newMetadata Metadata
 		if err := json.Unmarshal(fileContent, &newMetadata); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal metadata file %s: %w", metadataPath, err)
 		}
 
 		// Merge with parent metadata, overriding existing keys
-		mergedMetadata := make(map[string]any)
-		for k, v := range parentMetadata {
-			mergedMetadata[k] = v
+		mergedMetadata := &Metadata{Metadata: map[string]FileMetadata{}}
+		for filename, fileMetadata := range parentMetadata.Metadata {
+			if !strings.HasPrefix(filename, dirName) {
+				// skip entries which are not meant for this (sub-)directory
+				continue
+			}
+			fname := strings.TrimPrefix(strings.TrimPrefix(filename, dirName), string(filepath.Separator))
+			mergedMetadata.Metadata[fname] = fileMetadata
 		}
-		for k, v := range newMetadata {
-			mergedMetadata[k] = v
+
+		if newMetadata.Metadata != nil {
+			for filename, fileMetadata := range newMetadata.Metadata {
+				for k, v := range fileMetadata {
+					if mergedMetadata.Metadata[filename] == nil {
+						mergedMetadata.Metadata[filename] = map[string]any{}
+					}
+					mergedMetadata.Metadata[filename][k] = v
+				}
+			}
 		}
 
 		return mergedMetadata, nil

--- a/pkg/client/metadata.go
+++ b/pkg/client/metadata.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const MetadataFilename = ".knowledge.json"
+
+type Metadata struct {
+	Metadata map[string]any `json:"metadata"`
+	// TODO (idea): add other fields like description here, so we can hierarchically build a dataset description? Challenge is pruning and merging.
+}
+
+func loadAndMergeMetadata(dirPath string, parentMetadata map[string]any) (map[string]any, error) {
+	metadataPath := filepath.Join(dirPath, MetadataFilename)
+	if _, err := os.Stat(metadataPath); err == nil { // Metadata file exists
+		fileContent, err := os.ReadFile(metadataPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read metadata file %s: %w", metadataPath, err)
+		}
+
+		var newMetadata map[string]any
+		if err := json.Unmarshal(fileContent, &newMetadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal metadata file %s: %w", metadataPath, err)
+		}
+
+		// Merge with parent metadata, overriding existing keys
+		mergedMetadata := make(map[string]any)
+		for k, v := range parentMetadata {
+			mergedMetadata[k] = v
+		}
+		for k, v := range newMetadata {
+			mergedMetadata[k] = v
+		}
+
+		return mergedMetadata, nil
+	}
+
+	// No metadata file, return parent metadata as is
+	return parentMetadata, nil
+}

--- a/pkg/client/standalone.go
+++ b/pkg/client/standalone.go
@@ -68,7 +68,7 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 		return 0, err
 	}
 
-	ingestFile := func(path string) error {
+	ingestFile := func(path string, extraMetadata map[string]any) error {
 		// Gather metadata
 		finfo, err := os.Stat(path)
 		if err != nil {
@@ -95,6 +95,7 @@ func (c *StandaloneClient) IngestPaths(ctx context.Context, datasetID string, op
 				ModifiedAt:   finfo.ModTime(),
 			},
 			IsDuplicateFuncName: opts.IsDuplicateFuncName,
+			ExtraMetadata:       extraMetadata,
 		}
 
 		if opts != nil {

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -29,7 +29,6 @@ type IngestOpts struct {
 
 // Ingest loads a document from a reader and adds it to the dataset.
 func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, content []byte, opts IngestOpts) ([]string, error) {
-
 	if name == "" {
 		return nil, fmt.Errorf("name is required")
 	}

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -24,6 +24,7 @@ type IngestOpts struct {
 	IsDuplicateFunc     IsDuplicateFunc
 	TextSplitterOpts    *textsplitter.TextSplitterOpts
 	IngestionFlows      []flows.IngestionFlow
+	ExtraMetadata       map[string]any
 }
 
 // Ingest loads a document from a reader and adds it to the dataset.
@@ -147,8 +148,14 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 		return nil, fmt.Errorf("%w (file %q)", &documentloader.UnsupportedFileTypeError{FileType: filetype}, opts.FileMetadata.AbsolutePath)
 	}
 
-	// Mandatory Transformation: Add filename to metadata
-	em := &transformers.ExtraMetadata{Metadata: map[string]any{"filename": filename, "absPath": opts.FileMetadata.AbsolutePath}}
+	// Mandatory Transformation: Add filename to metadata -> append extraMetadata, but do not override filename or absPath
+	metadata := map[string]any{"filename": filename, "absPath": opts.FileMetadata.AbsolutePath}
+	for k, v := range opts.ExtraMetadata {
+		if _, ok := metadata[k]; !ok {
+			metadata[k] = v
+		}
+	}
+	em := &transformers.ExtraMetadata{Metadata: metadata}
 	ingestionFlow.Transformations = append(ingestionFlow.Transformations, em)
 
 	docs, err := ingestionFlow.Run(ctx, bytes.NewReader(content))


### PR DESCRIPTION
Ref #118 

When ingesting a file or directory (recursively or not), we're now checking if there is a `.knowledge.json` file present in the directory. It's structured like this:
```json
{
  "metadata": {
    "foo.pdf": {
      "baz": "bom",
      "foo": "bar"
    },
    "somedir/bar.pdf": {
      "x": "y"
    }
  }
}
```
This will add the defined k/v pairs as metadata to the documents in the vector store.
`.knowledge.json` files in nested directories will be merged (with override) with parent metadata files.

## Notes

1. I went with `.knowledge.json` instead of `.metadata.json` because I felt like the latter could be too "common" and we'd run into conflicts. By default, we're including hidden files in the ingestion process, so `.knowledge.json` is not explicitly being ignored.
2. It's JSON with an explicit `metadata` entry so we can add additional fields for new features in the future, e.g. directory content descriptions, etc. which can be merged with dataset metadata for routing retrieval