### PR TITLE
feat: add progress indication for embedding generation process

### DIFF
--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -160,8 +160,12 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 				defer sem.Release(1)
 
 				ingestedFilesCount++
-				currentMetadata := metadataStack[len(metadataStack)-1]
-				return ingestionFunc(path, currentMetadata.Metadata[filepath.Base(path)]) // FIXME: metadata
+				var fileMetadata FileMetadata
+				if len(metadataStack) > 0 {
+					currentMetadata := metadataStack[len(metadataStack)-1]
+					fileMetadata = currentMetadata.Metadata[filepath.Base(path)]
+				}
+				return ingestionFunc(path, fileMetadata)
 			})
 		}
 

--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -181,7 +181,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 	// Add documents to VectorStore -> This generates the embeddings
 	slog.Debug("Ingesting documents", "count", len(docs))
 
-	log.ToCtx(ctx, log.FromCtx(ctx).With("phase", "store").With("num_documents", len(docs)))
+	ctx = log.ToCtx(ctx, log.FromCtx(ctx).With("phase", "store").With("num_documents", len(docs)))
 
 	docIDs, err := s.Vectorstore.AddDocuments(ctx, docs, datasetID)
 	if err != nil {


### PR DESCRIPTION
This gives some progress indication for the embeddings generation.
Unfortunately, without modifying the chromem-go code for this, we cannot get the `"progress": "1/3"` style output here, so maybe in Otto we can just do a counter based on the `"status": "starting"` with `"num_documents": 3` being the total number of times it should appear.

```
{"time":"2024-09-19T14:56:15.374927781+02:00","level":"INFO","msg":"Adding documents to collection (generating embeddings)","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"vectorstore","vectorstore":"chromem-go","status":"starting"}
{"time":"2024-09-19T14:56:15.374966246+02:00","level":"INFO","msg":"Creating embedding","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"embedding","status":"starting"}
{"time":"2024-09-19T14:56:15.374975889+02:00","level":"INFO","msg":"Creating embedding","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"embedding","status":"starting"}
{"time":"2024-09-19T14:56:15.375093968+02:00","level":"INFO","msg":"Creating embedding","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"embedding","status":"starting"}
{"time":"2024-09-19T14:56:15.609623657+02:00","level":"INFO","msg":"Created embedding","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"embedding","status":"completed"}
{"time":"2024-09-19T14:56:15.748787889+02:00","level":"INFO","msg":"Created embedding","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"embedding","status":"completed"}
{"time":"2024-09-19T14:56:16.205515467+02:00","level":"INFO","msg":"Created embedding","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"embedding","status":"completed"}
{"time":"2024-09-19T14:56:16.205883188+02:00","level":"INFO","msg":"Added documents to collection (generated embeddings)","flow":"ingestion","rootPath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","filepath":".local/testdata/metadata/Reunion-Under-The-Stars.pdf","phase":"store","num_documents":3,"stage":"vectorstore","vectorstore":"chromem-go","status":"completed"}
```