### PR TITLE
Fix: Remove embedding logs to make output concise

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -115,16 +115,11 @@ func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingPr
 		}
 	}
 
-	embeddingFunc, err := embeddingProvider.EmbeddingFunc()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create embedding function: %w", err)
-	}
-
 	slog.Debug("Using embedding model provider", "provider", embeddingProvider.Name(), "config", output.RedactSensitive(embeddingProvider.Config()))
 
 	ds := &Datastore{
 		Index:                  idx,
-		Vectorstore:            chromem.New(vsdb, LogEmbeddingFunc(embeddingFunc)),
+		Vectorstore:            chromem.New(vsdb, nil),
 		EmbeddingModelProvider: embeddingProvider,
 	}
 


### PR DESCRIPTION
We are printing a ton of embedding logs which makes otto hard to save the output when file is too big.