### PR TITLE
Fix: add proper status to finished state and unsupported files

### DIFF
--- a/pkg/datastore/ingest.go
+++ b/pkg/datastore/ingest.go
@@ -144,6 +144,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 	}
 
 	if ingestionFlow.Load == nil {
+		statusLog.With("status", "unsupported").Info(fmt.Sprintf("Unsupported file types: %s", filetype))
 		return nil, fmt.Errorf("%w (file %q)", &documentloader.UnsupportedFileTypeError{FileType: filetype}, opts.FileMetadata.AbsolutePath)
 	}
 
@@ -165,6 +166,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 
 	if len(docs) == 0 {
 		statusLog.With("status", "skipped").With("reason", "no documents").Debug("No documents loaded")
+		statusLog.With("status", "finished").Info("Ingested document", "num_documents", 0)
 		return nil, nil
 	}
 
@@ -222,7 +224,7 @@ func (s *Datastore) Ingest(ctx context.Context, datasetID string, name string, c
 		return nil, fmt.Errorf("failed to create file: %w", tx.Error)
 	}
 
-	statusLog.With("status", "completed").Info("Ingested document", "num_documents", len(docIDs), "absolute_path", dbFile.FileMetadata.AbsolutePath)
+	statusLog.With("status", "finished").Info("Ingested document", "num_documents", len(docIDs), "absolute_path", dbFile.FileMetadata.AbsolutePath)
 
 	return docIDs, nil
 }


### PR DESCRIPTION
We need to add proper status to indicate finished state. `Completed` state is not enough because it could be completed state in earlier step while it is still running. 
Also for unsupported files we also emit log so that the file will have a status showing unsupported.

https://github.com/gptscript-ai/otto/issues/86
https://github.com/gptscript-ai/otto/issues/87