### PR TITLE
Fix: update to latest embedding model, apply timeout  and corrupted collection fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.0
 replace (
 	github.com/hupe1980/golc => github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7 // nbformat extension
 	github.com/ledongthuc/pdf => github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3 // fix for reading some PDFs: https://github.com/ledongthuc/pdf/pull/36 + https://github.com/iwilltry42/pdf/pull/2
-	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20240913181922-26d9f0c42cf0
+	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20241007125139-c67134210c5b
 	github.com/tmc/langchaingo => github.com/StrongMonkey/langchaingo v0.0.0-20240617180437-9af4bee04c8b // Context-Aware Markdown Splitting
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.0
 replace (
 	github.com/hupe1980/golc => github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7 // nbformat extension
 	github.com/ledongthuc/pdf => github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3 // fix for reading some PDFs: https://github.com/ledongthuc/pdf/pull/36 + https://github.com/iwilltry42/pdf/pull/2
-	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20241007125139-c67134210c5b
+	github.com/philippgille/chromem-go => github.com/iwilltry42/chromem-go v0.0.0-20241008123102-a14ad41590c3
 	github.com/tmc/langchaingo => github.com/StrongMonkey/langchaingo v0.0.0-20240617180437-9af4bee04c8b // Context-Aware Markdown Splitting
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/iwilltry42/bm25-go v0.0.0-20240909111832-a928590cc9da h1:aqahDXw6bOtbupzBGZpnV57M3JShpN0jrtd6cyclH8I=
 github.com/iwilltry42/bm25-go v0.0.0-20240909111832-a928590cc9da/go.mod h1:AmA5WoRtPljzo03tlOVOoLKPh9doUNUQrtrHaq5VkUg=
-github.com/iwilltry42/chromem-go v0.0.0-20241007125139-c67134210c5b h1:WnxefSvaBsbg0nDmBuJziI/eGlhW33r/hcjUmZfRIHE=
-github.com/iwilltry42/chromem-go v0.0.0-20241007125139-c67134210c5b/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
+github.com/iwilltry42/chromem-go v0.0.0-20241008123102-a14ad41590c3 h1:RvBuDVIqScpOD5NWj1LggfI3EFHjLyy4g6ijjk6zSns=
+github.com/iwilltry42/chromem-go v0.0.0-20241008123102-a14ad41590c3/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7 h1:2AzzbKVW1iP2F+ovqJKq801l6tgxYPt9m2zFKbs+i/Y=
 github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7/go.mod h1:w692KzkSTSvXROfyu+jYauNXB4YaL1s8zHPDMnNW88o=
 github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3 h1:rCVwFT7Q+HxpijWfSzKTYX4pCDMS7oy/I/WzU30VXyI=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/iwilltry42/bm25-go v0.0.0-20240909111832-a928590cc9da h1:aqahDXw6bOtbupzBGZpnV57M3JShpN0jrtd6cyclH8I=
 github.com/iwilltry42/bm25-go v0.0.0-20240909111832-a928590cc9da/go.mod h1:AmA5WoRtPljzo03tlOVOoLKPh9doUNUQrtrHaq5VkUg=
-github.com/iwilltry42/chromem-go v0.0.0-20240913181922-26d9f0c42cf0 h1:ijp65OiWBK24XMVlmIU0TO4ZmzDXsnXgeLtmwYTKFPE=
-github.com/iwilltry42/chromem-go v0.0.0-20240913181922-26d9f0c42cf0/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
+github.com/iwilltry42/chromem-go v0.0.0-20241007125139-c67134210c5b h1:WnxefSvaBsbg0nDmBuJziI/eGlhW33r/hcjUmZfRIHE=
+github.com/iwilltry42/chromem-go v0.0.0-20241007125139-c67134210c5b/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7 h1:2AzzbKVW1iP2F+ovqJKq801l6tgxYPt9m2zFKbs+i/Y=
 github.com/iwilltry42/golc v0.0.113-0.20240802113826-d065a3c5b0c7/go.mod h1:w692KzkSTSvXROfyu+jYauNXB4YaL1s8zHPDMnNW88o=
 github.com/iwilltry42/pdf v0.0.0-20240517145113-99fbaebc5dd3 h1:rCVwFT7Q+HxpijWfSzKTYX4pCDMS7oy/I/WzU30VXyI=

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -103,7 +103,7 @@ func NewDatastore(dsn string, automigrate bool, vectorDBPath string, embeddingPr
 
 	var vsdb *cg.DB
 	if !isArchive {
-		vsdb, err = cg.NewPersistentDB(vectorDBPath, false)
+		vsdb, err = cg.NewPersistentDB(vectorDBPath, false, cg.WithOnCorruptedCollectionBehavior(cg.OnCorruptedDelete))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/datastore/embeddings/openai/openai.go
+++ b/pkg/datastore/embeddings/openai/openai.go
@@ -1,13 +1,14 @@
 package openai
 
 import (
-	"dario.cat/mergo"
 	"fmt"
-	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/load"
-	cg "github.com/philippgille/chromem-go"
 	"log/slog"
 	"net/url"
 	"strings"
+
+	"dario.cat/mergo"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/load"
+	cg "github.com/philippgille/chromem-go"
 )
 
 const EmbeddingModelProviderOpenAIName string = "openai"
@@ -16,7 +17,7 @@ type EmbeddingModelProviderOpenAI struct {
 	BaseURL           string            `usage:"OpenAI API base" default:"https://api.openai.com/v1" env:"OPENAI_BASE_URL" koanf:"baseURL"`
 	APIKey            string            `usage:"OpenAI API key (not required if used with clicky-chats)" default:"sk-foo" env:"OPENAI_API_KEY" koanf:"apiKey" mapstructure:"apiKey" export:"false"`
 	Model             string            `usage:"OpenAI model" default:"gpt-4" env:"OPENAI_MODEL" koanf:"openai-model"`
-	EmbeddingModel    string            `usage:"OpenAI Embedding model" default:"text-embedding-ada-002" env:"OPENAI_EMBEDDING_MODEL" koanf:"embeddingModel" export:"required"`
+	EmbeddingModel    string            `usage:"OpenAI Embedding model" default:"text-embedding-3-small" env:"OPENAI_EMBEDDING_MODEL" koanf:"embeddingModel" export:"required"`
 	EmbeddingEndpoint string            `usage:"OpenAI Embedding endpoint" default:"/embeddings" env:"OPENAI_EMBEDDING_ENDPOINT" koanf:"embeddingEndpoint"`
 	APIVersion        string            `usage:"OpenAI API version (for Azure)" default:"2024-02-01" env:"OPENAI_API_VERSION" koanf:"apiVersion"`
 	APIType           string            `usage:"OpenAI API type (OPEN_AI, AZURE, AZURE_AD, ...)" default:"OPEN_AI" env:"OPENAI_API_TYPE" koanf:"apiType"`

--- a/pkg/datastore/embeddings/vertex/vertex.go
+++ b/pkg/datastore/embeddings/vertex/vertex.go
@@ -1,11 +1,12 @@
 package vertex
 
 import (
-	"dario.cat/mergo"
 	"fmt"
+	"strings"
+
+	"dario.cat/mergo"
 	"github.com/gptscript-ai/knowledge/pkg/datastore/embeddings/load"
 	cg "github.com/philippgille/chromem-go"
-	"strings"
 )
 
 type EmbeddingProviderVertex struct {
@@ -48,11 +49,10 @@ func (p *EmbeddingProviderVertex) fillDefaults() error {
 }
 
 func (p *EmbeddingProviderVertex) EmbeddingFunc() (cg.EmbeddingFunc, error) {
-	cfg := cg.NewVertexConfig(p.APIKey, p.Project, cg.EmbeddingModelVertex(p.Model))
 	if p.APIEndpoint != "" {
-		cfg = cfg.WithAPIEndpoint(p.APIEndpoint)
+		return cg.NewEmbeddingFuncVertex(p.APIKey, p.Project, cg.EmbeddingModelVertex(p.Model), cg.WithVertexAPIEndpoint(p.APIEndpoint)), nil
 	}
-	return cg.NewEmbeddingFuncVertex(cfg), nil
+	return cg.NewEmbeddingFuncVertex(p.APIKey, p.Project, cg.EmbeddingModelVertex(p.Model)), nil
 }
 
 func (p *EmbeddingProviderVertex) Config() any {


### PR DESCRIPTION
This PR updates to use latest embedding model from openai and also apply the timeout fix for embedding api requests which could be block the ingestion 