### PR TITLE
add: use .knowignore in top-level ingestion path if exists

### DIFF
--- a/pkg/client/ignore.go
+++ b/pkg/client/ignore.go
@@ -10,14 +10,54 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )
 
+const DefaultIgnoreFile = ".knowignore"
+
 var DefaultIgnorePatterns = []gitignore.Pattern{
-	gitignore.ParsePattern(MetadataFilename, nil), // Knowledge Metadata file
-	gitignore.ParsePattern("~$*", nil),            // MS Office temp files
-	gitignore.ParsePattern("$*", nil),             // Likely hidden/tempfiles
+	gitignore.ParsePattern(DefaultIgnoreFile, nil), // Default ignore patterns
+	gitignore.ParsePattern(MetadataFilename, nil),  // Knowledge Metadata file
+	gitignore.ParsePattern("~$*", nil),             // MS Office temp files
+	gitignore.ParsePattern("$*", nil),              // Likely hidden/tempfiles
 }
 
 func isIgnored(ignore gitignore.Matcher, path string) bool {
 	return ignore.Match(strings.Split(path, string(filepath.Separator)), false)
+}
+
+func readDefaultIgnoreFile(dirPath string) ([]gitignore.Pattern, error) {
+
+	ignoreFilePath := filepath.Join(dirPath, DefaultIgnoreFile)
+	_, err := os.Stat(ignoreFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to check if ignore file %q exists: %w", ignoreFilePath, err)
+	}
+
+	return readIgnoreFile(ignoreFilePath)
+}
+
+func useDefaultIgnoreFileIfExists(path string) ([]gitignore.Pattern, error) {
+
+	var err error
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	finfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if path %q exists: %w", path, err)
+	}
+	if !finfo.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	ignorePatterns, err := readDefaultIgnoreFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read default ignore file: %w", err)
+	}
+
+	return ignorePatterns, nil
 }
 
 func readIgnoreFile(path string) ([]gitignore.Pattern, error) {


### PR DESCRIPTION
If there is a `.knowignore` file in the root path of the ingested directory, it will be used.
Also, this PR now sorts the ignore patterns in increasing priority as expected by the gitignore library:
1. Default ignore file
2. User-provided ignore file
3. User-provided ignore extensions
4. Default ignore patterns