### PR TITLE
Add delete file options, don't run prune

### DIFF
--- a/delete-file.gpt
+++ b/delete-file.gpt
@@ -1,0 +1,4 @@
+Name: Knowledge File Deletion
+Description: Delete a file.
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool delete-file "${GPTSCRIPT_INPUT}"

--- a/ingest.gpt
+++ b/ingest.gpt
@@ -2,4 +2,4 @@ Name: Knowledge Ingestion
 Description: Ingest content into a dataset.
 Credential: github.com/gptscript-ai/credentials/model-provider
 
-#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool ingest --prune --dataset ${GPTSCRIPT_DATASET} "${GPTSCRIPT_INPUT}"
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool ingest --dataset ${GPTSCRIPT_DATASET} "${GPTSCRIPT_INPUT}"

--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -123,7 +123,12 @@ func ingestPaths(ctx context.Context, c Client, opts *IngestPathsOpts, datasetID
 					metadataStack = append(metadataStack, *newMetadata)
 					return nil
 				}
-				if isIgnored(ignore, subPath) {
+
+				rel, err := filepath.Rel(path, subPath)
+				if err != nil {
+					return fmt.Errorf("failed to get rel path, error: %w", err)
+				}
+				if isIgnored(ignore, rel) {
 					slog.Debug("Ignoring file", "path", subPath, "ignorefile", opts.IgnoreFile, "ignoreExtensions", opts.IgnoreExtensions)
 					return nil
 				}


### PR DESCRIPTION
This PR adds delete-file.gpt so that it can delete file on demand, and also disable prune when ingesting. It also fixed a bug where ignore file doesn't work 