### PR TITLE
add: structured json dataloader

### DIFF
--- a/examples/structured-ingestion/example.json
+++ b/examples/structured-ingestion/example.json
@@ -1,0 +1,21 @@
+{
+  "type": "knowledge",
+  "metadata": {
+    "originalSource": "https://example.com",
+    "filename": "foo.pdf"
+  },
+  "documents": [
+    {
+      "metadata": {
+        "page": 1
+      },
+        "content": "This is the first page of the document."
+    },
+    {
+      "metadata": {
+        "page": 2
+      },
+      "content": "This is the second page of the document."
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jmcarbo/stopwords v1.1.9
 	github.com/joho/godotenv v1.5.1
+	github.com/knadh/koanf/maps v0.1.1
 	github.com/knadh/koanf/parsers/json v0.1.0
 	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/env v0.1.0
@@ -126,7 +127,6 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
-	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/pkg/client/ignore.go
+++ b/pkg/client/ignore.go
@@ -24,7 +24,6 @@ func isIgnored(ignore gitignore.Matcher, path string) bool {
 }
 
 func readDefaultIgnoreFile(dirPath string) ([]gitignore.Pattern, error) {
-
 	ignoreFilePath := filepath.Join(dirPath, DefaultIgnoreFile)
 	_, err := os.Stat(ignoreFilePath)
 	if err != nil {
@@ -38,7 +37,6 @@ func readDefaultIgnoreFile(dirPath string) ([]gitignore.Pattern, error) {
 }
 
 func useDefaultIgnoreFileIfExists(path string) ([]gitignore.Pattern, error) {
-
 	var err error
 	path, err = filepath.Abs(path)
 	if err != nil {

--- a/pkg/datastore/documentloader/documentloaders.go
+++ b/pkg/datastore/documentloader/documentloaders.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/pdf/gopdf"
+	"github.com/gptscript-ai/knowledge/pkg/datastore/documentloader/structured"
 	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore/types"
 
 	golcdocloaders "github.com/hupe1980/golc/documentloader"
@@ -42,6 +43,8 @@ func GetDocumentLoaderConfig(name string) (any, error) {
 		return golcdocloaders.CSVOptions{}, nil
 	case "notebook":
 		return golcdocloaders.NotebookOptions{}, nil
+	case "structured":
+		return structured.Structured{}, nil
 	default:
 		return nil, fmt.Errorf("unknown document loader %q", name)
 	}
@@ -151,6 +154,11 @@ func GetDocumentLoaderFunc(name string, config any) (LoaderFunc, error) {
 			}
 			return FromLangchain(lcgodocloaders.NewText(strings.NewReader(text))).Load(ctx)
 		}, nil
+	case "structured":
+		if config != nil {
+			return nil, fmt.Errorf("structured document loader does not accept configuration")
+		}
+		return new(structured.Structured).Load, nil
 	default:
 		return nil, fmt.Errorf("unknown document loader %q", name)
 	}

--- a/pkg/datastore/documentloader/structured/structured.go
+++ b/pkg/datastore/documentloader/structured/structured.go
@@ -1,0 +1,41 @@
+package structured
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	vs "github.com/gptscript-ai/knowledge/pkg/vectorstore/types"
+	"github.com/knadh/koanf/maps"
+)
+
+type StructuredInputDocument struct {
+	Metadata map[string]any `json:"metadata"`
+	Content  string         `json:"content"`
+}
+
+type StructuredInput struct {
+	Metadata  map[string]any            `json:"metadata"`
+	Documents []StructuredInputDocument `json:"documents"`
+}
+
+type Structured struct{}
+
+func (s *Structured) Load(ctx context.Context, reader io.Reader) ([]vs.Document, error) {
+	var input StructuredInput
+	if err := json.NewDecoder(reader).Decode(&input); err != nil {
+		return nil, fmt.Errorf("failed to decode input: %w", err)
+	}
+
+	docs := make([]vs.Document, 0, len(input.Documents))
+	for _, doc := range input.Documents {
+		maps.Merge(maps.Copy(input.Metadata), doc.Metadata)
+		docs = append(docs, vs.Document{
+			Content:  doc.Content,
+			Metadata: doc.Metadata,
+		})
+	}
+
+	return docs, nil
+}

--- a/pkg/vectorstore/sqlite-vec/sqlite-vec.go
+++ b/pkg/vectorstore/sqlite-vec/sqlite-vec.go
@@ -54,7 +54,6 @@ func (v *VectorStore) Close() error {
 }
 
 func (v *VectorStore) prepareTables(ctx context.Context) error {
-
 	err := v.db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s
 		(
 			id TEXT PRIMARY KEY,
@@ -84,11 +83,9 @@ func (v *VectorStore) CreateCollection(ctx context.Context, collection string) e
 		embedding float[%d] distance_metric=cosine
 	)
     `, collection, dimensionality))
-
 }
 
 func (v *VectorStore) AddDocuments(ctx context.Context, docs []vs.Document, collection string) ([]string, error) {
-
 	stmt, _, err := v.db.Prepare(fmt.Sprintf(`INSERT INTO %s_vec(document_id, embedding) VALUES (?, ?)`, collection))
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare statement: %w", err)
@@ -215,7 +212,6 @@ func (v *VectorStore) SimilaritySearch(ctx context.Context, query string, numDoc
 	}
 
 	return docs, nil
-
 }
 
 func (v *VectorStore) RemoveCollection(ctx context.Context, collection string) error {
@@ -265,7 +261,6 @@ func (v *VectorStore) RemoveDocument(ctx context.Context, documentID string, col
 		if stmt.Err() != nil {
 			return fmt.Errorf("failed to execute statement: %w", stmt.Err())
 		}
-
 	} else {
 		ids = []string{documentID}
 	}
@@ -284,7 +279,6 @@ func (v *VectorStore) RemoveDocument(ctx context.Context, documentID string, col
 	}
 
 	for _, id := range ids {
-
 		slog.Debug("deleting document from sqlite-vec", "id", id)
 
 		if err := embStmt.BindText(1, id); err != nil {
@@ -310,7 +304,6 @@ func (v *VectorStore) RemoveDocument(ctx context.Context, documentID string, col
 		if err := colStmt.Reset(); err != nil {
 			return fmt.Errorf("failed to reset statement: %w", err)
 		}
-
 	}
 
 	return nil
@@ -358,7 +351,6 @@ func (v *VectorStore) GetDocuments(ctx context.Context, collection string, where
 		if stmt.Err() != nil {
 			return nil, fmt.Errorf("failed to execute statement: %w", stmt.Err())
 		}
-
 	}
 	return docs, nil
 }


### PR DESCRIPTION
Example format:

```json
{
  "metadata": {
    "source": "https://example.com",
    "filename": "foo.pdf"
  },
  "documents": [
    {
      "metadata": {
        "page": 1
      },
        "content": "This is the first page of the document."
    },
    {
      "metadata": {
        "page": 2
      },
      "content": "This is the second page of the document."
    }
  ]
}
```

`knowledge load` supports this as a default now: `knowledge load mydoc.pdf -` will print the loaded content from mydoc.pdf in the above format.
You may as well verify your own structured output via `diff <(cat examples/structured-ingestion/example.json) <(knowledge load examples/structured-ingestion/example.json --loader "structured" -)` (there may be formatting differences).
Note: `knowledge load` sets the global `source` metadata to the source file that you give it.